### PR TITLE
fix: raise compile-time errors from macros

### DIFF
--- a/src/driver/proxy/driver.cr
+++ b/src/driver/proxy/driver.cr
@@ -35,7 +35,7 @@ class PlaceOS::Driver::Proxy::Driver
 
   # This deliberately prevents compilation if called from driver code
   def []=(status, value)
-    {{ "Remote drivers are read only. Please use the public interface to modify state".id }}
+    {{ raise "Remote drivers are read only. Please use the public interface to modify state" }}
   end
 
   def implements?(interface) : Bool

--- a/src/driver/proxy/drivers.cr
+++ b/src/driver/proxy/drivers.cr
@@ -28,7 +28,7 @@ class PlaceOS::Driver::Proxy::Drivers
 
   # This deliberately prevents compilation if called from driver code
   def []=(status, value)
-    {{ "Remote drivers are read only. Please use the public interface to modify state".id }}
+    {{ raise "Remote drivers are read only. Please use the public interface to modify state" }}
   end
 
   def implements?(interface) : Bool
@@ -48,7 +48,7 @@ class PlaceOS::Driver::Proxy::Drivers
 
   # This deliberately prevents compilation if called from driver code
   def subscribe(status, &callback : (PlaceOS::Driver::Subscriptions::IndirectSubscription, String) -> Nil) : PlaceOS::Driver::Subscriptions::IndirectSubscription
-    {{ "Can't subscribe to state on a collection of drivers".id }}
+    {{ raise "Can't subscribe to state on a collection of drivers" }}
   end
 
   class Responses

--- a/src/driver/utilities/discovery.cr
+++ b/src/driver/utilities/discovery.cr
@@ -65,7 +65,7 @@ abstract class PlaceOS::Driver
       {% if name.type.types[1].stringify == "::Nil" || name.type.types[1].stringify == "Nil" %}
         {% optional = true %}
       {% else %}
-        {{ "Can only specify a single driver class when aliasing".id }}
+        {{ raise "Can only specify a single driver class when aliasing" }}
       {% end %}
     {% end %}
 
@@ -79,7 +79,7 @@ abstract class PlaceOS::Driver
         # puts "{{name.var}} - {{ntype.name}} - {{ntype.type_vars[0]}} - {{optional}}"
         {% ntype = ntype.type_vars[0].stringify %}
       {% else %}
-        {{ "Only generic type supported is Array".id }}
+        {{ raise "Only generic type supported is Array" }}
       {% end %}
     {% end %}
 


### PR DESCRIPTION
Ensure that issues detected during macro expansion raise appropriate
compile-time errors.