### PR TITLE
fix driver protocol and remove retriable.cr

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,5 @@
 name: driver
 version: 1.0.0
-license: MIT
 
 dependencies:
   connect-proxy:
@@ -21,8 +20,8 @@ dependencies:
   redis:
     github: stefanwille/crystal-redis
     version: ~> 2.5
-  retriable:
-    github: Sija/retriable.cr
+  simple_retry:
+    github: spider-gazelle/simple_retry
   ssh2:
     github: spider-gazelle/ssh2.cr
   tasker:

--- a/spec/driver_proxy_spec.cr
+++ b/spec/driver_proxy_spec.cr
@@ -50,7 +50,7 @@ describe PlaceOS::Driver::Proxy::Driver do
     # Check the exec request
     raw_data = Bytes.new(4096)
     bytes_read = output.read(raw_data)
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.payload.should eq(%({"__exec__":"function1","function1":{}}))
     req_out.reply.should eq("reply_id")
     req_out.id.should eq("mod-1234")
@@ -87,7 +87,7 @@ describe PlaceOS::Driver::Proxy::Driver do
     # Check the exec request
     raw_data = Bytes.new(4096)
     bytes_read = output.read(raw_data)
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.payload.should eq(%({"__exec__":"function2","function2":{"arg1":12345}}))
 
     # Execute a remote function with named arguments
@@ -97,7 +97,7 @@ describe PlaceOS::Driver::Proxy::Driver do
     # Check the exec request
     raw_data = Bytes.new(4096)
     bytes_read = output.read(raw_data)
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.payload.should eq(%({"__exec__":"function3","function3":{"arg1":null,"arg2":12345}}))
 
     # Ensure timeouts work!!
@@ -107,7 +107,7 @@ describe PlaceOS::Driver::Proxy::Driver do
     # Check the exec request
     raw_data = Bytes.new(4096)
     bytes_read = output.read(raw_data)
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.payload.should eq(%({"__exec__":"function1","function1":{}}))
     req_out.reply.should eq("reply_id")
     req_out.id.should eq("mod-1234")

--- a/spec/drivers_proxy_spec.cr
+++ b/spec/drivers_proxy_spec.cr
@@ -75,23 +75,17 @@ describe PlaceOS::Driver::Proxy::Drivers do
     # Check the exec request
     raw_data = Bytes.new(4096)
     bytes_read = output.read(raw_data)
-    tokenizer = ::Tokenizer.new do |io|
-      begin
-        io.read_bytes(Int32) + 4
-      rescue
-        0
-      end
-    end
+    tokenizer = Tokenizer.new(Bytes[0x00, 0x03])
     messages = tokenizer.extract(raw_data[0, bytes_read])
 
     message = messages[0]
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(message[4, message.bytesize - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(message[2, message.bytesize - 4]))
     req_out.payload.should eq(%({"__exec__":"function1","function1":{}}))
     req_out.id.should eq("mod-999")
     req_out.reply.should eq("reply_id")
 
     message = messages[1]
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(message[4, message.bytesize - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(message[2, message.bytesize - 4]))
     req_out.payload.should eq(%({"__exec__":"function1","function1":{}}))
     req_out.id.should eq("mod-888")
     req_out.reply.should eq("reply_id")

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -47,7 +47,7 @@ class Helper
     bytes_read = output.read(raw_data)
 
     # Check start responded
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq(driver_id)
     req_out.cmd.should eq("start")
 

--- a/spec/logger_spec.cr
+++ b/spec/logger_spec.cr
@@ -17,7 +17,7 @@ describe PlaceOS::Driver::Logger do
 
     raw_data = Bytes.new(4096)
     bytes_read = output.read(raw_data)
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq("mod-123")
     req_out.payload.should eq(%{[0,"whatwhat"]})
 
@@ -28,7 +28,7 @@ describe PlaceOS::Driver::Logger do
     logger.warn "hello-logs"
 
     bytes_read = output.read(raw_data)
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq("mod-123")
     req_out.payload.should eq(%{[2,"hello-logs"]})
 
@@ -59,7 +59,7 @@ describe PlaceOS::Driver::Logger do
 
     raw_data = Bytes.new(4096)
     bytes_read = output.read(raw_data)
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq("mod-123")
     req_out.payload.should eq(%{[0,"whatwhat"]})
 
@@ -71,7 +71,7 @@ describe PlaceOS::Driver::Logger do
     logger.warn { "hello-logs" }
 
     bytes_read = output.read(raw_data)
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq("mod-123")
     req_out.payload.should eq(%{[2,"hello-logs"]})
 

--- a/spec/process_manager_spec.cr
+++ b/spec/process_manager_spec.cr
@@ -32,7 +32,7 @@ describe PlaceOS::Driver::ProcessManager do
     bytes_read = output.read(raw_data)
 
     # Check response was returned
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq(driver_id)
     req_out.cmd.should eq("result")
     req_out.payload.should eq("3")
@@ -54,7 +54,7 @@ describe PlaceOS::Driver::ProcessManager do
     bytes_read = output.read(raw_data)
 
     # Check response was returned
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq(driver_id)
     req_out.cmd.should eq("result")
     req_out.payload.should eq("\"DisplayPort\"")
@@ -136,7 +136,7 @@ describe PlaceOS::Driver::ProcessManager do
     Fiber.yield
     raw_data = Bytes.new(4096)
     bytes_read = output.read(raw_data)
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     loaded = Array(String).from_json(req_out.payload.not_nil!)
     loaded.should eq(["mod_1234"])
 
@@ -190,7 +190,7 @@ describe PlaceOS::Driver::ProcessManager do
     bytes_read = output.read(raw_data)
 
     # Check response was returned
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq(driver_id)
     req_out.cmd.should eq("result")
     req_out.payload.should eq("you fool!")
@@ -219,7 +219,7 @@ describe PlaceOS::Driver::ProcessManager do
     bytes_read = output.read(raw_data)
 
     # Check response was returned
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq(driver_id)
     req_out.cmd.should eq("result")
     req_out.payload.should eq("null")
@@ -263,7 +263,7 @@ describe PlaceOS::Driver::ProcessManager do
     bytes_read = output.read(raw_data)
 
     # Check response was returned
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq(driver_id)
     req_out.cmd.should eq("result")
     req_out.payload.should eq(%("hello steve"))
@@ -289,7 +289,7 @@ describe PlaceOS::Driver::ProcessManager do
     bytes_read = output.read(raw_data)
 
     # Check response was returned
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq(driver_id)
     req_out.cmd.should eq("result")
     req_out.payload.should eq(%(11))
@@ -314,7 +314,7 @@ describe PlaceOS::Driver::ProcessManager do
     bytes_read = output.read(raw_data)
 
     # Check response was returned
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq(driver_id)
     req_out.cmd.should eq("result")
     req_out.payload.should eq(%(205))
@@ -337,7 +337,7 @@ describe PlaceOS::Driver::ProcessManager do
     bytes_read = output.read(raw_data)
 
     # Check response was returned
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq(driver_id)
     req_out.cmd.should eq("result")
     req_out.payload.should eq("oops")
@@ -362,7 +362,7 @@ describe PlaceOS::Driver::ProcessManager do
     bytes_read = output.read(raw_data)
 
     # Check response was returned
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq(driver_id)
     req_out.cmd.should eq("result")
     req_out.payload.should eq("nooooo")

--- a/spec/protocol_spec.cr
+++ b/spec/protocol_spec.cr
@@ -28,7 +28,7 @@ describe PlaceOS::Driver::Protocol do
 
     raw_data = Bytes.new(4096)
     bytes_read = output.read(raw_data)
-    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[4, bytes_read - 4]))
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq(req.id)
   end
 

--- a/src/driver.cr
+++ b/src/driver.cr
@@ -1,5 +1,3 @@
-# https://github.com/Sija/retriable.cr#kernel-extension
-require "retriable/core_ext/kernel"
 require "option_parser"
 
 abstract class PlaceOS::Driver

--- a/src/driver/driver-specs/mock_driver.cr
+++ b/src/driver/driver-specs/mock_driver.cr
@@ -21,7 +21,7 @@ abstract class DriverSpecs::MockDriver
   def initialize(@module_id : String)
     @__storage__ = PlaceOS::Driver::Storage.new(module_id)
     @__status__ = PlaceOS::Driver::Status.new
-    @__logger__ = Logger.new(STDOUT, Logger::Severity::DEBUG, Logger::Formatter.new { |severity, datetime, progname, message, io|
+    @__logger__ = Logger.new(STDOUT, Logger::Severity::DEBUG, Logger::Formatter.new { |severity, _, _, message, io|
       label = severity.unknown? ? "ANY" : severity.to_s
       io << label.rjust(5) << " -- " << module_id << ": " << message
     })

--- a/src/driver/driver-specs/runner.cr
+++ b/src/driver/driver-specs/runner.cr
@@ -404,7 +404,7 @@ class DriverSpecs
         @expected_transmissions.delete(channel)
       end
     else
-      return @transmissions.shift
+      @transmissions.shift
     end
   end
 

--- a/src/driver/logger.cr
+++ b/src/driver/logger.cr
@@ -7,8 +7,7 @@ class PlaceOS::Driver
     io << String.build do |str|
       str << "level=" << label << " time="
       datetime.to_rfc3339(str)
-      progname ||= PROGRAM_NAME
-      progname = PROGRAM_NAME if progname.empty?
+      progname ||= Process.pid
       str << " progname=" << progname << " message=" << message
     end
   end
@@ -16,7 +15,7 @@ class PlaceOS::Driver
   # Allow signals to change the log level at run-time
   logging = Proc(Signal, Nil).new do |signal|
     level = signal.usr1? ? ::Logger::DEBUG : ::Logger::INFO
-    LOGGER.info " > Log level changed to #{level}"
+    LOGGER.info "> Log level changed to #{level}"
     LOGGER.level = level
     signal.ignore
   end

--- a/src/driver/logger.cr
+++ b/src/driver/logger.cr
@@ -7,7 +7,9 @@ class PlaceOS::Driver
     io << String.build do |str|
       str << "level=" << label << " time="
       datetime.to_rfc3339(str)
-      str << " progname=" << (progname || PROGRAM_NAME) << " message=" << message
+      progname ||= PROGRAM_NAME
+      progname = PROGRAM_NAME if progname.empty?
+      str << " progname=" << progname << " message=" << message
     end
   end
 

--- a/src/driver/logger.cr
+++ b/src/driver/logger.cr
@@ -1,37 +1,62 @@
 require "logger"
 
-class PlaceOS::Driver::Logger < Logger
-  def initialize(module_id : String, logger_io = STDOUT, @protocol = Protocol.instance)
-    super(logger_io)
-    @debugging = false
-    @progname = module_id
-    self.level = Logger::WARN
-    self.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
-      # method=DELETE path=/build/drivers%2Faca%2Fspec_helper.cr/ status=200 duration=32.65ms request_id=8a14cef3-15ea-4d2d-ad55-cff5799d4add
+class PlaceOS::Driver
+  LOGGER = ::Logger.new(STDOUT, level: ::Logger::INFO)
+  LOGGER.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
+    label = severity.unknown? ? "ANY" : severity.to_s
+    io << String.build do |str|
+      str << "level=" << label << " time="
+      datetime.to_rfc3339(str)
+      str << " progname=" << (progname || PROGRAM_NAME) << " message=" << message
+    end
+  end
 
-      label = severity.unknown? ? "ANY" : severity.to_s
-      io << String.build do |str|
-        str << "level=" << label << " time="
-        datetime.to_rfc3339(str)
-        str << " progname=" << progname << " message=" << message
+  # Allow signals to change the log level at run-time
+  logging = Proc(Signal, Nil).new do |signal|
+    level = signal.usr1? ? ::Logger::DEBUG : ::Logger::INFO
+    LOGGER.info " > Log level changed to #{level}"
+    LOGGER.level = level
+    signal.ignore
+  end
+
+  # Turn on DEBUG level logging `kill -s USR1 %PID`
+  # Default production log levels (INFO and above) `kill -s USR2 %PID`
+  Signal::USR1.trap &logging
+  Signal::USR2.trap &logging
+
+  class Logger < Logger
+    def initialize(module_id : String, logger_io = STDOUT, @protocol = Protocol.instance)
+      super(logger_io)
+      @debugging = false
+      @progname = module_id
+      self.level = Logger::WARN
+      self.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
+        # method=DELETE path=/build/drivers%2Faca%2Fspec_helper.cr/ status=200 duration=32.65ms request_id=8a14cef3-15ea-4d2d-ad55-cff5799d4add
+
+        label = severity.unknown? ? "ANY" : severity.to_s
+        io << String.build do |str|
+          str << "level=" << label << " time="
+          datetime.to_rfc3339(str)
+          str << " progname=" << progname << " message=" << message
+        end
       end
     end
-  end
 
-  @protocol : Protocol
-  property :debugging
+    @protocol : Protocol
+    property :debugging
 
-  def log(severity, message, progname = nil)
-    if @debugging
-      message = message.to_s
-      @protocol.request @progname, "debug", [severity, message]
+    def log(severity, message, progname = nil)
+      if @debugging
+        message = message.to_s
+        @protocol.request @progname, "debug", [severity, message]
+      end
+      return if severity < level || !@io
+      write(severity, Time.local, progname || @progname, message)
     end
-    return if severity < level || !@io
-    write(severity, Time.local, progname || @progname, message)
-  end
 
-  def log(severity, progname = nil)
-    return if !@debugging && (severity < level || !@io)
-    log(severity, yield, progname)
+    def log(severity, progname = nil)
+      return if !@debugging && (severity < level || !@io)
+      log(severity, yield, progname)
+    end
   end
 end

--- a/src/driver/logger.cr
+++ b/src/driver/logger.cr
@@ -4,10 +4,10 @@ class PlaceOS::Driver
   LOGGER = ::Logger.new(STDOUT, level: ::Logger::INFO)
   LOGGER.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
     label = severity.unknown? ? "ANY" : severity.to_s
+    progname = Process.pid.to_s if progname.empty?
     io << String.build do |str|
       str << "level=" << label << " time="
       datetime.to_rfc3339(str)
-      progname ||= Process.pid
       str << " progname=" << progname << " message=" << message
     end
   end

--- a/src/driver/protocol.cr
+++ b/src/driver/protocol.cr
@@ -6,9 +6,9 @@ require "./protocol/request"
 require "./logger"
 
 STDIN.blocking = false
-STDIN.sync = true
+STDIN.sync = false
 STDERR.blocking = false
-STDERR.sync = true
+STDERR.sync = false
 STDOUT.blocking = false
 STDOUT.sync = true
 
@@ -221,9 +221,9 @@ class PlaceOS::Driver::Protocol
           @next_requests[seq] = request
         end
 
-        json = request.to_json
-        @io.write_bytes json.bytesize
-        @io.write json.to_slice
+        json = request.to_json.to_slice
+        @io.write_bytes json.size, IO::ByteFormat::LittleEndian
+        @io.write json
         @io.flush
       rescue e
         LOGGER.fatal "Fatal error #{e.inspect_with_backtrace}"

--- a/src/driver/protocol.cr
+++ b/src/driver/protocol.cr
@@ -3,6 +3,7 @@ require "json"
 require "tasker"
 require "tokenizer"
 require "./protocol/request"
+require "./logger"
 
 STDIN.blocking = false
 STDIN.sync = true
@@ -97,9 +98,11 @@ class PlaceOS::Driver::Protocol
       # Requests should run in async so they don't block the processing loop
       spawn(same_thread: true) { process(message.not_nil!) }
     end
+    LOGGER.debug { "protocol processor terminated" }
   end
 
   def process(message : Request)
+    LOGGER.debug { "protocol processing: #{message}" }
     callbacks = case message.cmd
                 when "start"
                   # New instance of id == mod_id
@@ -143,6 +146,7 @@ class PlaceOS::Driver::Protocol
     callbacks.each do |callback|
       response = callback.call(message)
       if response
+        LOGGER.debug { "protocol queuing response: #{response}" }
         @producer.send({response, nil})
         break
       end
@@ -151,6 +155,7 @@ class PlaceOS::Driver::Protocol
     message.payload = nil
     message.error = error.message
     message.backtrace = error.backtrace?
+    LOGGER.debug { "protocol queuing error response: #{message}" }
     @producer.send({message, nil})
   end
 
@@ -159,6 +164,7 @@ class PlaceOS::Driver::Protocol
     if payload
       req.payload = raw ? payload.to_s : payload.to_json
     end
+    LOGGER.debug { "protocol queuing request: #{req}" }
     @producer.send({req, nil})
     req
   end
@@ -169,6 +175,8 @@ class PlaceOS::Driver::Protocol
       req.payload = raw ? payload.to_s : payload.to_json
     end
     channel = Channel(Request).new(1)
+
+    LOGGER.debug { "protocol queuing request: #{req}" }
     @producer.send({req, channel})
     channel
   end
@@ -201,6 +209,7 @@ class PlaceOS::Driver::Protocol
         break unless req_data
 
         request, channel = req_data
+        LOGGER.debug { "protocol sending reqest (expects response #{!!channel}): #{request}" }
 
         # Expects a response
         if channel
@@ -217,8 +226,7 @@ class PlaceOS::Driver::Protocol
         @io.write json.to_slice
         @io.flush
       rescue e
-        STDOUT.puts "#{PROGRAM_NAME}: Fatal error #{e.inspect_with_backtrace}"
-        STDOUT.flush
+        LOGGER.fatal "Fatal error #{e.inspect_with_backtrace}"
         exit(2)
       end
     end
@@ -236,24 +244,25 @@ class PlaceOS::Driver::Protocol
       bytes_read = @io.read(raw_data)
       break if bytes_read == 0 # IO was closed
 
+      LOGGER.debug { "protocol received #{bytes_read}" }
+
       @tokenizer.extract(raw_data[0, bytes_read]).each do |message|
         string = nil
         begin
           string = String.new(message[4, message.bytesize - 4])
+          LOGGER.debug { "protocol queuing #{string}" }
           @processor.send Request.from_json(string)
         rescue error
-          puts "error parsing request #{string.inspect}\n#{error.inspect_with_backtrace}"
+          LOGGER.warn "error parsing request #{string.inspect}\n#{error.inspect_with_backtrace}"
         end
       end
     end
   rescue IO::Error | Errno
     # Input stream closed. This should only occur on termination
-    STDOUT.puts "#{PROGRAM_NAME}: IO terminated, exiting cleanly"
-    STDOUT.flush
+    LOGGER.info "IO terminated, exiting cleanly"
   rescue e
     begin
-      STDOUT.puts "#{PROGRAM_NAME}: Fatal error #{e.inspect_with_backtrace}"
-      STDOUT.flush
+      LOGGER.fatal e.inspect_with_backtrace
     rescue
     end
     exit(1)

--- a/src/driver/protocol.cr
+++ b/src/driver/protocol.cr
@@ -102,7 +102,7 @@ class PlaceOS::Driver::Protocol
   end
 
   def process(message : Request)
-    LOGGER.debug { "protocol processing: #{message}" }
+    LOGGER.debug { "protocol processing: #{message.inspect}" }
     callbacks = case message.cmd
                 when "start"
                   # New instance of id == mod_id
@@ -146,7 +146,7 @@ class PlaceOS::Driver::Protocol
     callbacks.each do |callback|
       response = callback.call(message)
       if response
-        LOGGER.debug { "protocol queuing response: #{response}" }
+        LOGGER.debug { "protocol queuing response: #{response.inspect}" }
         @producer.send({response, nil})
         break
       end
@@ -155,7 +155,7 @@ class PlaceOS::Driver::Protocol
     message.payload = nil
     message.error = error.message
     message.backtrace = error.backtrace?
-    LOGGER.debug { "protocol queuing error response: #{message}" }
+    LOGGER.debug { "protocol queuing error response: #{message.inspect}" }
     @producer.send({message, nil})
   end
 
@@ -164,7 +164,7 @@ class PlaceOS::Driver::Protocol
     if payload
       req.payload = raw ? payload.to_s : payload.to_json
     end
-    LOGGER.debug { "protocol queuing request: #{req}" }
+    LOGGER.debug { "protocol queuing request: #{req.inspect}" }
     @producer.send({req, nil})
     req
   end
@@ -176,7 +176,7 @@ class PlaceOS::Driver::Protocol
     end
     channel = Channel(Request).new(1)
 
-    LOGGER.debug { "protocol queuing request: #{req}" }
+    LOGGER.debug { "protocol queuing request: #{req.inspect}" }
     @producer.send({req, channel})
     channel
   end
@@ -209,7 +209,7 @@ class PlaceOS::Driver::Protocol
         break unless req_data
 
         request, channel = req_data
-        LOGGER.debug { "protocol sending reqest (expects response #{!!channel}): #{request}" }
+        LOGGER.debug { "protocol sending (expects reply #{!!channel}): #{request.inspect}" }
 
         # Expects a response
         if channel

--- a/src/driver/protocol/management.cr
+++ b/src/driver/protocol/management.cr
@@ -20,7 +20,7 @@ class PlaceOS::Driver::Protocol::Management
 
     @tokenizer = ::Tokenizer.new do |io|
       begin
-        io.read_bytes(Int32) + 4
+        io.read_bytes(Int32, IO::ByteFormat::LittleEndian) + 4
       rescue
         0
       end
@@ -330,7 +330,7 @@ class PlaceOS::Driver::Protocol::Management
       @driver_path,
       {"-p"},
       input: stdin_reader,
-      output: STDOUT,
+      output: Redirect::Inherit,
       error: stderr_writer
     ) do |process|
       fetch_pid.resolve process.pid
@@ -365,7 +365,7 @@ class PlaceOS::Driver::Protocol::Management
       @tokenizer.extract(raw_data[0, bytes_read]).each do |message|
         string = nil
         begin
-          string = String.new(message[4, message.bytesize - 4])
+          string = String.new(message[4, message.size - 4])
           @logger.debug { "manager #{@driver_path} processing #{string}" }
           request = Request.from_json(string)
           spawn(same_thread: true) { process(request) }

--- a/src/driver/protocol/management.cr
+++ b/src/driver/protocol/management.cr
@@ -18,13 +18,7 @@ class PlaceOS::Driver::Protocol::Management
       hash[key] = [] of Proc(String, Nil)
     end
 
-    @tokenizer = ::Tokenizer.new do |io|
-      begin
-        io.read_bytes(Int32, IO::ByteFormat::LittleEndian) + 4
-      rescue
-        0
-      end
-    end
+    @tokenizer = Tokenizer.new(Bytes[0x00, 0x03])
 
     @last_exit_code = 0
     @launch_count = 0
@@ -330,7 +324,7 @@ class PlaceOS::Driver::Protocol::Management
       @driver_path,
       {"-p"},
       input: stdin_reader,
-      output: Redirect::Inherit,
+      output: Process::Redirect::Inherit,
       error: stderr_writer
     ) do |process|
       fetch_pid.resolve process.pid
@@ -349,6 +343,8 @@ class PlaceOS::Driver::Protocol::Management
     start_process unless @modules.empty?
   end
 
+  MESSAGE_INDICATOR = "\x00\x02"
+
   private def process_comms(io, loaded)
     raw_data = Bytes.new(2048)
 
@@ -365,8 +361,15 @@ class PlaceOS::Driver::Protocol::Management
       @tokenizer.extract(raw_data[0, bytes_read]).each do |message|
         string = nil
         begin
-          string = String.new(message[4, message.size - 4])
-          @logger.debug { "manager #{@driver_path} processing #{string}" }
+          string = String.new(message[0..-3])
+          junk, _, string = string.rpartition(MESSAGE_INDICATOR)
+          @logger.debug do
+            if junk.empty?
+              "manager #{@driver_path} processing #{string}"
+            else
+              "manager #{@driver_path} processing #{string}, ignoring #{junk}"
+            end
+          end
           request = Request.from_json(string)
           spawn(same_thread: true) { process(request) }
         rescue error

--- a/src/driver/subscriptions.cr
+++ b/src/driver/subscriptions.cr
@@ -1,6 +1,6 @@
+require "simple_retry"
 require "logger"
 require "redis"
-require "retriable/core_ext/kernel"
 
 # TODO:: we need to be scheduling these onto the correct thread
 class PlaceOS::Driver::Subscriptions
@@ -127,7 +127,11 @@ class PlaceOS::Driver::Subscriptions
   private def monitor_changes(wait)
     wait.close
 
-    retry max_interval: 5.seconds do
+    SimpleRetry.try_to(
+      base_interval: 1.second,
+      max_interval: 5.seconds,
+      randomise: 500.milliseconds
+    ) do
       begin
         wait = Channel(Nil).new
 

--- a/src/driver/transport/http.cr
+++ b/src/driver/transport/http.cr
@@ -210,8 +210,8 @@ class PlaceOS::Driver
       else
         # Only a single request can occur at a time
         # crystal does not provide any queuing mechanism so this mutex does the trick
-        with_shared_client do |client|
-          client.exec(method.to_s.upcase, uri.full_path, headers, body)
+        with_shared_client do |shared_client|
+          shared_client.exec(method.to_s.upcase, uri.full_path, headers, body)
         end
       end
     end

--- a/src/driver/transport/ssh.cr
+++ b/src/driver/transport/ssh.cr
@@ -1,3 +1,4 @@
+require "simple_retry"
 require "socket"
 require "tasker"
 require "ssh2"
@@ -58,7 +59,11 @@ class PlaceOS::Driver
       tokenizer = @tokenizer
       tokenizer.clear if tokenizer
 
-      retry max_interval: 10.seconds do
+      SimpleRetry.try_to(
+        base_interval: 1.second,
+        max_interval: 10.seconds,
+        randomise: 500.milliseconds
+      ) do
         supported_methods = nil
 
         begin

--- a/src/driver/transport/tcp.cr
+++ b/src/driver/transport/tcp.cr
@@ -1,3 +1,4 @@
+require "simple_retry"
 require "socket"
 
 class PlaceOS::Driver::TransportTCP < PlaceOS::Driver::Transport
@@ -29,7 +30,11 @@ class PlaceOS::Driver::TransportTCP < PlaceOS::Driver::Transport
     if @makebreak
       start_socket(connect_timeout)
     else
-      retry max_interval: 10.seconds do
+      SimpleRetry.try_to(
+        base_interval: 1.second,
+        max_interval: 10.seconds,
+        randomise: 500.milliseconds
+      ) do
         start_socket(connect_timeout)
       end
     end

--- a/src/driver/transport/udp.cr
+++ b/src/driver/transport/udp.cr
@@ -1,3 +1,4 @@
+require "simple_retry"
 require "socket"
 require "openssl"
 
@@ -27,7 +28,11 @@ class PlaceOS::Driver::TransportUDP < PlaceOS::Driver::Transport
       return unless socket.closed?
     end
 
-    retry max_interval: 10.seconds do
+    SimpleRetry.try_to(
+      base_interval: 1.second,
+      max_interval: 10.seconds,
+      randomise: 500.milliseconds
+    ) do
       begin
         @socket = socket = UDPSocket.new
         socket.connect(@ip, @port)

--- a/src/driver/transport/websocket.cr
+++ b/src/driver/transport/websocket.cr
@@ -1,3 +1,4 @@
+require "simple_retry"
 require "socket"
 
 class PlaceOS::Driver::TransportWebsocket < PlaceOS::Driver::Transport
@@ -34,7 +35,11 @@ class PlaceOS::Driver::TransportWebsocket < PlaceOS::Driver::Transport
     tokenizer = @tokenizer
     tokenizer.clear if tokenizer
 
-    retry max_interval: 10.seconds do
+    SimpleRetry.try_to(
+      base_interval: 1.second,
+      max_interval: 10.seconds,
+      randomise: 500.milliseconds
+    ) do
       start_socket(connect_timeout)
     end
   end


### PR DESCRIPTION
As STDERR might be used for error output the STDERR protocol needs to be encapsulated to allow for this.
retriable.cr erroring both made me aware of this and the fact that it wasn't working.