### PR TITLE
refactor: migrate to `Log`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ install:
   - sleep 5
 
 script:
-  - crystal spec
+  - crystal spec -v --error-trace
 
 language: crystal

--- a/shard.yml
+++ b/shard.yml
@@ -2,6 +2,8 @@ name: driver
 version: 1.2.0
 
 dependencies:
+  action-controller:
+    github: spider-gazelle/action-controller
   connect-proxy:
     github: spider-gazelle/connect-proxy
   debug:

--- a/spec/driver_proxy_spec.cr
+++ b/spec/driver_proxy_spec.cr
@@ -45,7 +45,7 @@ describe PlaceOS::Driver::Proxy::Driver do
 
     # Execute a remote function
     result = system[:Display_1].function1
-    result.is_a?(Concurrent::Future(JSON::Any)).should eq(true)
+    result.is_a?(::Future::Compute(JSON::Any)).should eq(true)
 
     # Check the exec request
     raw_data = Bytes.new(4096)
@@ -66,7 +66,7 @@ describe PlaceOS::Driver::Proxy::Driver do
 
     # Attempt to execute a function that doesn't exist
     result = system[:Display_1].function8
-    result.is_a?(Concurrent::Future(JSON::Any)).should eq(true)
+    result.is_a?(::Future::Compute(JSON::Any)).should eq(true)
 
     expect_raises(Exception) do
       result.get
@@ -74,7 +74,7 @@ describe PlaceOS::Driver::Proxy::Driver do
 
     # Attempt to execute a function with invalid arguments
     result = system[:Display_1].function2
-    result.is_a?(Concurrent::Future(JSON::Any)).should eq(true)
+    result.is_a?(::Future::Compute(JSON::Any)).should eq(true)
 
     expect_raises(Exception) do
       result.get
@@ -82,7 +82,7 @@ describe PlaceOS::Driver::Proxy::Driver do
 
     # Execute a remote function with arguments
     result = system[:Display_1].function2(12_345)
-    result.is_a?(Concurrent::Future(JSON::Any)).should eq(true)
+    result.is_a?(::Future::Compute(JSON::Any)).should eq(true)
 
     # Check the exec request
     raw_data = Bytes.new(4096)
@@ -92,7 +92,7 @@ describe PlaceOS::Driver::Proxy::Driver do
 
     # Execute a remote function with named arguments
     result = system[:Display_1].function3(arg2: 12_345)
-    result.is_a?(Concurrent::Future(JSON::Any)).should eq(true)
+    result.is_a?(::Future::Compute(JSON::Any)).should eq(true)
 
     # Check the exec request
     raw_data = Bytes.new(4096)
@@ -102,7 +102,7 @@ describe PlaceOS::Driver::Proxy::Driver do
 
     # Ensure timeouts work!!
     result = system[:Display_1].function1
-    result.is_a?(Concurrent::Future(JSON::Any)).should eq(true)
+    result.is_a?(::Future::Compute(JSON::Any)).should eq(true)
 
     # Check the exec request
     raw_data = Bytes.new(4096)

--- a/spec/logger_spec.cr
+++ b/spec/logger_spec.cr
@@ -30,7 +30,7 @@ describe PlaceOS::Driver::Log do
     bytes_read = output.read(raw_data)
     req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq("mod-123")
-    req_out.payload.should eq(%{[2,"hello-logs"]})
+    req_out.payload.should eq(%{[3,"hello-logs"]})
 
     (std_out.size > 10).should eq(true)
   end
@@ -73,7 +73,7 @@ describe PlaceOS::Driver::Log do
     bytes_read = output.read(raw_data)
     req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
     req_out.id.should eq("mod-123")
-    req_out.payload.should eq(%{[2,"hello-logs"]})
+    req_out.payload.should eq(%{[3,"hello-logs"]})
 
     (std_out.size > 10).should eq(true)
   end

--- a/spec/logger_spec.cr
+++ b/spec/logger_spec.cr
@@ -1,19 +1,19 @@
 require "./helper"
 
-describe PlaceOS::Driver::Logger do
+describe PlaceOS::Driver::Log do
   it "should send outgoing requests" do
     proto, _, output = Helper.protocol
     std_out = IO::Memory.new
 
     # By default debug messages are ignored
-    logger = PlaceOS::Driver::Logger.new("mod-123", std_out, proto)
-    logger.debug "this should do nothing"
+    logger = PlaceOS::Driver::Log.new("mod-123", std_out, protocol: proto)
+    logger.debug { "this should do nothing" }
 
     (std_out.size > 0).should eq(false)
 
     # However when debugging we want these to be routed to the developer
     logger.debugging = true
-    logger.debug "whatwhat"
+    logger.debug { "whatwhat" }
 
     raw_data = Bytes.new(4096)
     bytes_read = output.read(raw_data)
@@ -25,7 +25,7 @@ describe PlaceOS::Driver::Logger do
     (std_out.size > 0).should eq(false)
 
     # Warning and above logs should go to both
-    logger.warn "hello-logs"
+    logger.warn { "hello-logs" }
 
     bytes_read = output.read(raw_data)
     req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
@@ -40,7 +40,7 @@ describe PlaceOS::Driver::Logger do
     std_out = IO::Memory.new
 
     # By default debug messages are ignored
-    logger = PlaceOS::Driver::Logger.new("mod-123", std_out, proto)
+    logger = PlaceOS::Driver::Log.new("mod-123", std_out, proto)
     in_block = false
     logger.debug {
       in_block = true

--- a/spec/protocol_management_spec.cr
+++ b/spec/protocol_management_spec.cr
@@ -55,7 +55,7 @@ describe PlaceOS::Driver::Protocol::Management do
       "implemented_in_base_class": {}
     }))
 
-    logged.should eq(%([1,"testing info message"]))
+    logged.should eq(%([2,"testing info message"]))
 
     manager.info.should eq(["mod-management-test"])
 

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -154,10 +154,8 @@ describe PlaceOS::Driver::Queue do
   end
 
   it "should allow for connected state to be updated" do
-    std_out = IO::Memory.new
-    logger = ::Logger.new(std_out)
     connected = false
-    queue = PlaceOS::Driver::Queue.new(logger) { |state| connected = state }
+    queue = PlaceOS::Driver::Queue.new { |state| connected = state }
 
     connected.should eq(false)
     queue.online = true

--- a/spec/test_build.cr
+++ b/spec/test_build.cr
@@ -5,7 +5,7 @@ class Helper
   abstract class HelperBase < PlaceOS::Driver
     def implemented_in_base_class
       self[:test] = ["bob"]
-      logger.info "testing info message"
+      logger.info { "testing info message" }
       puts "woot!"
     end
   end

--- a/src/driver.cr
+++ b/src/driver.cr
@@ -408,6 +408,11 @@ macro finished
     end
   end
 
+  # Set up logging
+  backend = ::Log::IOBackend.new(STDOUT)
+  backend.formatter = PlaceOS::Driver::LOG_FORMATTER
+  ::Log.builder.bind("*", ::Log::Severity::Info, backend)
+
   # Launch the process manager by default, this can be overriten for testing
   if exec_process_manager
     process = PlaceOS::Driver::ProcessManager.new

--- a/src/driver.cr
+++ b/src/driver.cr
@@ -1,5 +1,7 @@
 require "option_parser"
 
+require "./driver/logger"
+
 abstract class PlaceOS::Driver
   module Proxy
   end
@@ -20,7 +22,7 @@ abstract class PlaceOS::Driver
     @__setting__ : Settings,
     @__queue__ : Queue,
     @__transport__ : Transport,
-    @__logger__ : PlaceOS::Driver::Logger,
+    @__logger__ : PlaceOS::Driver::Log,
     @__schedule__ = Proxy::Scheduler.new,
     @__subscriptions__ = Proxy::Subscriptions.new,
     @__driver_model__ = DriverModel.from_json(%({"udp":false,"tls":false,"makebreak":false,"settings":{},"role":1}))

--- a/src/driver/driver-specs/mock_driver.cr
+++ b/src/driver/driver-specs/mock_driver.cr
@@ -21,10 +21,7 @@ abstract class DriverSpecs::MockDriver
   def initialize(@module_id : String)
     @__storage__ = PlaceOS::Driver::Storage.new(module_id)
     @__status__ = PlaceOS::Driver::Status.new
-    @__logger__ = Logger.new(STDOUT, Logger::Severity::DEBUG, Logger::Formatter.new { |severity, _, _, message, io|
-      label = severity.unknown? ? "ANY" : severity.to_s
-      io << label.rjust(5) << " -- " << module_id << ": " << message
-    })
+    @__logger__ = PlaceOS::Driver::Log.new(@module_id, STDOUT, ::Log::Severity::Debug)
 
     __init__
   end

--- a/src/driver/driver-specs/runner.cr
+++ b/src/driver/driver-specs/runner.cr
@@ -279,6 +279,8 @@ class DriverSpecs
                 @io.write json.to_slice
                 @io.flush
               end
+            else
+              puts "unexpected command in driver-runner server"
             end
           end
         rescue error

--- a/src/driver/logger.cr
+++ b/src/driver/logger.cr
@@ -21,6 +21,7 @@ class PlaceOS::Driver
   Signal::USR1.trap &log_level_change
   Signal::USR2.trap &log_level_change
 
+  # Custom backend that writes to a `PlaceOS::Driver::Protocol`
   class ProtocolBackend < ::Log::Backend
     getter protocol : Protocol
     getter formatter = PlaceOS::Driver::LOG_FORMATTER
@@ -44,6 +45,7 @@ class PlaceOS::Driver
     end
   end
 
+  # Custom Log that broadcasts to a `Log::IOBackend` and `PlaceOS::Driver::ProtocolBackend`
   class Log < ::Log
     getter broadcast_backend : ::Log::BroadcastBackend
     getter io_backend : ::Log::IOBackend

--- a/src/driver/proxy/driver.cr
+++ b/src/driver/proxy/driver.cr
@@ -128,7 +128,7 @@ class PlaceOS::Driver::Proxy::Driver
         if error = result.error
           backtrace = result.backtrace || [] of String
           exception = PlaceOS::Driver::RemoteException.new(result.payload, error, backtrace)
-          @system.logger.warn "#{exception.message}\n#{exception.backtrace?.try &.join("\n")}"
+          @system.logger.warn { "#{exception.message}\n#{exception.backtrace?.try &.join("\n")}" }
           raise exception
         else
           JSON.parse(result.payload.not_nil!)
@@ -138,7 +138,7 @@ class PlaceOS::Driver::Proxy::Driver
       raise "undefined method '#{function_name}' for #{@module_name}_#{@index} (#{@module_id})"
     end
   rescue error
-    @system.logger.warn error.inspect_with_backtrace
+    @system.logger.warn { error.inspect_with_backtrace }
     lazy { raise error; JSON.parse("") }
   end
 end

--- a/src/driver/proxy/drivers.cr
+++ b/src/driver/proxy/drivers.cr
@@ -52,7 +52,7 @@ class PlaceOS::Driver::Proxy::Drivers
   end
 
   class Responses
-    def initialize(@results : Array(Concurrent::Future(JSON::Any)))
+    def initialize(@results : Array(::Future::Compute(JSON::Any)))
     end
 
     @computed : Array(JSON::Any)?

--- a/src/driver/proxy/scheduler.cr
+++ b/src/driver/proxy/scheduler.cr
@@ -28,7 +28,9 @@ class PlaceOS::Driver::Proxy::Scheduler
     end
   end
 
-  def initialize(@logger = ::Logger.new(STDOUT))
+  getter logger : ::Log
+
+  def initialize(@logger = ::Log.for("driver.scheduler"))
     @scheduler = Tasker.instance
     @schedules = [] of TaskWrapper
     @terminated = false
@@ -98,7 +100,7 @@ class PlaceOS::Driver::Proxy::Scheduler
   private def run_now(block)
     block.call
   rescue error
-    @logger.error "in scheduled task on #{DriverManager.driver_class}\n#{error.inspect_with_backtrace}"
+    logger.error { "in scheduled task on #{DriverManager.driver_class}\n#{error.inspect_with_backtrace}" }
     raise error
   end
 end

--- a/src/driver/proxy/system.cr
+++ b/src/driver/proxy/system.cr
@@ -6,7 +6,7 @@ class PlaceOS::Driver::Proxy::System
   def initialize(
     @model : DriverModel::ControlSystem,
     @reply_id : String,
-    @logger : ::Logger = ::Logger.new(STDOUT),
+    @logger : ::Log = ::Log.for("driver.proxy.system"),
     @subscriptions : Proxy::Subscriptions = Proxy::Subscriptions.new
   )
     @system_id = @model.id
@@ -15,7 +15,8 @@ class PlaceOS::Driver::Proxy::System
   end
 
   @system_id : String
-  getter :logger
+
+  getter logger : ::Log
 
   def [](module_name)
     get_driver(*get_parts(module_name))
@@ -129,7 +130,7 @@ class PlaceOS::Driver::Proxy::System
       begin
         callback.call(subscription, "ready")
       rescue error
-        @logger.error "error in subscription callback\n#{error.inspect_with_backtrace}"
+        logger.error { "error in subscription callback\n#{error.inspect_with_backtrace}" }
       end
     end
 

--- a/src/driver/settings.cr
+++ b/src/driver/settings.cr
@@ -40,7 +40,7 @@ class PlaceOS::Driver::Settings
       begin
         extract {{klass}}, %json
       rescue ex : TypeCastError
-        logger.error "setting[#{%keys.join("->")}] expected to be type of {{klass}}"
+        logger.error { "setting[#{%keys.join("->")}] expected to be type of {{klass}}" }
         raise ex
       end
     else
@@ -56,7 +56,7 @@ class PlaceOS::Driver::Settings
       begin
         extract {{klass}}, %json
       rescue ex : TypeCastError
-        logger.error "setting[#{%keys.join("->")}] expected to be type of {{klass}}"
+        logger.error { "setting[#{%keys.join("->")}] expected to be type of {{klass}}" }
         raise ex
       end
     else

--- a/src/driver/subscriptions/channel_subscription.cr
+++ b/src/driver/subscriptions/channel_subscription.cr
@@ -4,12 +4,12 @@ class PlaceOS::Driver::Subscriptions::ChannelSubscription < PlaceOS::Driver::Sub
   def initialize(@channel : String, &@callback : (ChannelSubscription, String) ->)
   end
 
-  def callback(logger : ::Logger, message : String) : Nil
+  def callback(logger : ::Log, message : String) : Nil
     # Error handling is the responsibility of the callback
     # This is fine as this should only be used internally
     @callback.call(self, message)
   rescue e
-    logger.error "error in subscription callback\n#{e.message}\n#{e.backtrace?.try &.join("\n")}"
+    logger.error { "error in subscription callback\n#{e.message}\n#{e.backtrace?.try &.join("\n")}" }
   end
 
   getter :channel

--- a/src/driver/subscriptions/direct_subscription.cr
+++ b/src/driver/subscriptions/direct_subscription.cr
@@ -5,12 +5,12 @@ class PlaceOS::Driver::Subscriptions::DirectSubscription < PlaceOS::Driver::Subs
     @storage = PlaceOS::Driver::Storage.new(@module_id)
   end
 
-  def callback(logger : ::Logger, message : String) : Nil
+  def callback(logger : ::Log, message : String) : Nil
     # Error handling is the responsibility of the callback
     # This is fine as this should only be used internally
     @callback.call(self, message)
   rescue e
-    logger.error "error in subscription callback\n#{e.message}\n#{e.backtrace?.try &.join("\n")}"
+    logger.error { "error in subscription callback\n#{e.message}\n#{e.backtrace?.try &.join("\n")}" }
   end
 
   getter :module_id, :status

--- a/src/driver/subscriptions/indirect_subscription.cr
+++ b/src/driver/subscriptions/indirect_subscription.cr
@@ -4,12 +4,12 @@ class PlaceOS::Driver::Subscriptions::IndirectSubscription < PlaceOS::Driver::Su
   def initialize(@system_id : String, @module_name : String, @index : Int32, @status : String, &@callback : (IndirectSubscription, String) ->)
   end
 
-  def callback(logger : ::Logger, message : String) : Nil
+  def callback(logger : ::Log, message : String) : Nil
     # Error handling is the responsibility of the callback
     # This is fine as this should only be used internally
     @callback.call(self, message)
   rescue e
-    logger.error "error in subscription callback\n#{e.message}\n#{e.backtrace?.try &.join("\n")}"
+    logger.error { "error in subscription callback\n#{e.message}\n#{e.backtrace?.try &.join("\n")}" }
   end
 
   @storage : PlaceOS::Driver::Storage?

--- a/src/driver/subscriptions/subscription.cr
+++ b/src/driver/subscriptions/subscription.cr
@@ -1,7 +1,8 @@
+require "log"
 require "../storage"
 
 abstract class PlaceOS::Driver::Subscriptions::Subscription
-  abstract def callback(logger : ::Logger, message : String) : Nil
+  abstract def callback(logger : ::Log, message : String) : Nil
   abstract def subscribe_to : String?
   abstract def current_value : String?
 

--- a/src/driver/transport.cr
+++ b/src/driver/transport.cr
@@ -16,6 +16,8 @@ abstract class PlaceOS::Driver::Transport
     raise ::IO::EOFError.new("exec is only available to SSH transports")
   end
 
+  delegate logger, to: @queue
+
   # Many devices have a HTTP service. Might as well make it easy to access.
   macro inherited
     def http(method, path, body : ::HTTP::Client::BodyType = nil,
@@ -122,7 +124,7 @@ abstract class PlaceOS::Driver::Transport
           tls.verify_mode = OpenSSL::SSL::VerifyMode::NONE
         end
       rescue error
-        @logger.warn "issue configuring verify mode\n#{error.inspect_with_backtrace}"
+        Log.warn { "issue configuring verify mode\n#{error.inspect_with_backtrace}" }
         tls.verify_mode = OpenSSL::SSL::VerifyMode::NONE
       end
     end
@@ -141,7 +143,7 @@ abstract class PlaceOS::Driver::Transport
       process_message(data)
     end
   rescue error
-    @logger.error "error processing data\n#{error.inspect_with_backtrace}"
+    Log.error { "error processing data\n#{error.inspect_with_backtrace}" }
   end
 
   private def process_message(data)
@@ -161,6 +163,6 @@ abstract class PlaceOS::Driver::Transport
     # See spec for how this callback is expected to be used
     @received.call(data, task)
   rescue error
-    @logger.error "error processing received data\n#{error.inspect_with_backtrace}"
+    Log.error { "error processing received data\n#{error.inspect_with_backtrace}" }
   end
 end

--- a/src/driver/transport.cr
+++ b/src/driver/transport.cr
@@ -16,6 +16,7 @@ abstract class PlaceOS::Driver::Transport
     raise ::IO::EOFError.new("exec is only available to SSH transports")
   end
 
+  # Use `logger` of `Driver::Queue`
   delegate logger, to: @queue
 
   # Many devices have a HTTP service. Might as well make it easy to access.

--- a/src/driver/transport/udp.cr
+++ b/src/driver/transport/udp.cr
@@ -10,17 +10,14 @@ class PlaceOS::Driver::TransportUDP < PlaceOS::Driver::Transport
   def initialize(@queue : PlaceOS::Driver::Queue, @ip : String, @port : Int32, @settings : ::PlaceOS::Driver::Settings, @start_tls = false, @uri = nil, &@received : (Bytes, PlaceOS::Driver::Task?) -> Nil)
     @terminated = false
     @tls_started = false
-    @logger = @queue.logger
   end
 
   @uri : String?
-  @logger : ::Logger
   @socket : IO?
   @tls : OpenSSL::SSL::Context::Client?
   @settings : ::PlaceOS::Driver::Settings
 
   property :received
-  getter :logger
 
   def connect(connect_timeout : Int32 = 10) : Nil
     return if @terminated
@@ -66,7 +63,7 @@ class PlaceOS::Driver::TransportUDP < PlaceOS::Driver::Transport
         # Start consuming data from the socket
         spawn(same_thread: true) { consume_io }
       rescue error
-        @logger.info { "connecting to device\n#{error.inspect_with_backtrace}" }
+        logger.info { "connecting to device\n#{error.inspect_with_backtrace}" }
         raise error
       end
     end
@@ -133,7 +130,7 @@ class PlaceOS::Driver::TransportUDP < PlaceOS::Driver::Transport
     end
   rescue IO::Error
   rescue error
-    @logger.error "error consuming IO\n#{error.inspect_with_backtrace}"
+    logger.error { "error consuming IO\n#{error.inspect_with_backtrace}" }
   ensure
     connect
   end


### PR DESCRIPTION
Good for a merge once tested with a few drivers.
The branch can be specified in the `shard.yml` of a drivers repo like so...

```yaml
...
dependencies:
  driver:
    github: placeos/driver
    branch: refactor/log-migrate
...
```
Compatability is mostly preserved, the only migration effort required should be converting placing `String` calls to `logger` within a block. 