### PR TITLE
improvement: helpful errors when missing type restriction in a driver method

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 3.3.1
+version: 3.3.2
 
 dependencies:
   action-controller:

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -250,6 +250,8 @@ abstract class PlaceOS::Driver
                 {% for arg in args %}
                   {% arg_name = arg.name.stringify %}
 
+                  {% raise "#{@type}##{method.name} argument `#{arg.name}` is missing a type" if arg.restriction.is_a?(Nop) %}
+
                   {% if !arg.restriction.is_a?(Union) && arg.restriction.resolve < ::Enum %}
                     {% if arg.default_value.is_a?(Nop) %}
                       {{arg.name}}: ({{arg.restriction}}).parse(json[{{arg_name}}].as_s),


### PR DESCRIPTION
Explicit build error when a public driver method is missing a type.

Example:
```
Code in drivers/place/feature_test.cr:3:1

 3 | class Place::AcidTest < PlaceOS::Driver
     ^
Called macro defined in lib/placeos-driver/src/placeos-driver.cr:166:3

 166 | macro inherited

Which expanded to:

 > 1 | macro finished
       ^
Error: Place::AcidTest#perform_thing argument `name` is missing a type
```

Resolves #24 