### PR TITLE
fix(transcoder): add types to params

### DIFF
--- a/src/placeos-driver/utilities/transcoder.cr
+++ b/src/placeos-driver/utilities/transcoder.cr
@@ -7,7 +7,7 @@ module PlaceOS::Driver::Utilities::Transcoder
   end
 
   # Converts a byte array into bytes
-  def array_to_bytes(array : Array(Int32 | UInt8)) : Bytes
+  def array_to_bytes(array : Array(Int)) : Bytes
     bytes = Bytes.new(array.size)
     array.each_with_index do |byte, index|
       bytes[index] = 0_u8 | byte

--- a/src/placeos-driver/utilities/transcoder.cr
+++ b/src/placeos-driver/utilities/transcoder.cr
@@ -7,7 +7,7 @@ module PlaceOS::Driver::Utilities::Transcoder
   end
 
   # Converts a byte array into bytes
-  def array_to_bytes(array : Array(Int)) : Bytes
+  def array_to_bytes(array : Array(Int32 | UInt8)) : Bytes
     bytes = Bytes.new(array.size)
     array.each_with_index do |byte, index|
       bytes[index] = 0_u8 | byte

--- a/src/placeos-driver/utilities/transcoder.cr
+++ b/src/placeos-driver/utilities/transcoder.cr
@@ -1,13 +1,13 @@
 module PlaceOS::Driver::Utilities::Transcoder
   # Converts a hex encoded string into bytes
-  def hex_to_bytes(string)
+  def hex_to_bytes(string : String)
     string = string.gsub(/(0x|[^0-9A-Fa-f])*/, "")
     string = "0#{string}" if string.size % 2 > 0
     string.hexbytes
   end
 
   # Converts a byte array into bytes
-  def array_to_bytes(array)
+  def array_to_bytes(array : Array(UInt8)
     bytes = Bytes.new(array.size)
     array.each_with_index do |byte, index|
       bytes[index] = 0_u8 | byte

--- a/src/placeos-driver/utilities/transcoder.cr
+++ b/src/placeos-driver/utilities/transcoder.cr
@@ -1,13 +1,13 @@
 module PlaceOS::Driver::Utilities::Transcoder
   # Converts a hex encoded string into bytes
-  def hex_to_bytes(string : String) : Bytes
+  protected def hex_to_bytes(string)
     string = string.gsub(/(0x|[^0-9A-Fa-f])*/, "")
     string = "0#{string}" if string.size % 2 > 0
     string.hexbytes
   end
 
   # Converts a byte array into bytes
-  def array_to_bytes(array : Array(Int32 | UInt8)) : Bytes
+  protected def array_to_bytes(array)
     bytes = Bytes.new(array.size)
     array.each_with_index do |byte, index|
       bytes[index] = 0_u8 | byte

--- a/src/placeos-driver/utilities/transcoder.cr
+++ b/src/placeos-driver/utilities/transcoder.cr
@@ -1,13 +1,13 @@
 module PlaceOS::Driver::Utilities::Transcoder
   # Converts a hex encoded string into bytes
-  def hex_to_bytes(string : String)
+  def hex_to_bytes(string : String) : Bytes
     string = string.gsub(/(0x|[^0-9A-Fa-f])*/, "")
     string = "0#{string}" if string.size % 2 > 0
     string.hexbytes
   end
 
   # Converts a byte array into bytes
-  def array_to_bytes(array : Array(UInt8)
+  def array_to_bytes(array : Array(Int32 | UInt8)) : Bytes
     bytes = Bytes.new(array.size)
     array.each_with_index do |byte, index|
       bytes[index] = 0_u8 | byte


### PR DESCRIPTION
I wanted to do `def array_to_bytes(array : Array(Int))` instead of `def array_to_bytes(array : Array(UInt8))` so it doesn't matter what type of Int the Array has but the driver rest runner gives this error.

![image](https://user-images.githubusercontent.com/18463731/85715814-bd6ba000-b6e3-11ea-8dc3-1d89e2c6f05d.png)