### PR TITLE
fix(proxy driver): set default arguments on execute

### DIFF
--- a/spec/driver_proxy_spec.cr
+++ b/spec/driver_proxy_spec.cr
@@ -92,14 +92,14 @@ describe PlaceOS::Driver::Proxy::Driver do
       req_out.payload.should eq(%({"__exec__":"function2","function2":{"arg1":12345}}))
 
       # Execute a remote function with named arguments
-      result = system[:Display_1].function3(arg2: 12_345)
+      result = system[:Display_1].function3(arg2: 12_345, arg1: 123)
       result.is_a?(::Future::Compute(JSON::Any)).should eq(true)
 
       # Check the exec request
       raw_data = Bytes.new(4096)
       bytes_read = output.read(raw_data)
       req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
-      req_out.payload.should eq(%({"__exec__":"function3","function3":{"arg1":null,"arg2":12345}}))
+      req_out.payload.should eq(%({"__exec__":"function3","function3":{"arg1":123,"arg2":12345}}))
 
       # Ensure timeouts work!!
       result = system[:Display_1].function1

--- a/src/placeos-driver/proxy/driver.cr
+++ b/src/placeos-driver/proxy/driver.cr
@@ -98,12 +98,19 @@ class PlaceOS::Driver::Proxy::Driver
         # Apply the arguments
         index = 0
         named_keys = named_args.keys.map &.to_s
-        function.each_key do |arg_name|
+        function.each do |arg_name, details|
+          include_arg = false
           value = if named_keys.includes?(arg_name)
                     named_args[arg_name]?
                   else
                     index += 1
-                    arguments[index - 1]?
+                    if index < arguments.size
+                      arguments[index - 1]?
+                    elsif details.size > 1
+                      details[1]
+                    else
+                      raise "missing argument `#{arg_name} : #{details[0]}` for '#{function_name}' on #{@module_name}_#{@index} - #{@module_id}"
+                    end
                   end
 
           # Enums are special case

--- a/src/placeos-driver/proxy/driver.cr
+++ b/src/placeos-driver/proxy/driver.cr
@@ -103,9 +103,9 @@ class PlaceOS::Driver::Proxy::Driver
           value = if named_keys.includes?(arg_name)
                     named_args[arg_name]?
                   else
-                    index += 1
                     if index < arguments.size
-                      arguments[index - 1]?
+                      index += 1
+                      arguments[index - 1]
                     elsif details.size > 1
                       details[1]
                     else

--- a/src/placeos-driver/proxy/drivers.cr
+++ b/src/placeos-driver/proxy/drivers.cr
@@ -68,7 +68,11 @@ class PlaceOS::Driver::Proxy::Drivers
   # Collect all the futures from the function calls and make them available to the user
   macro method_missing(call)
     results = @drivers.map do |driver|
-      driver.{{call.name.id}}( {{*call.args}} {% if !call.named_args.is_a?(Nop) && call.named_args.size > 0 %}, {{**call.named_args}} {% end %} )
+      begin
+        driver.{{call.name.id}}( {{*call.args}} {% if !call.named_args.is_a?(Nop) && call.named_args.size > 0 %}, {{**call.named_args}} {% end %} )
+      rescue error
+        ::Future::Compute(JSON::Any).new(false) { raise error }
+      end
     end
 
     #}# TODO: at some point in the future use a future here. Currently blows up the compiler


### PR DESCRIPTION
the caller sets the default arguments not the receiver