### PR TITLE
refactor: enum flags

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 3.5.12
+version: 3.5.13
 
 dependencies:
   action-controller:

--- a/src/placeos-driver/proxy/driver.cr
+++ b/src/placeos-driver/proxy/driver.cr
@@ -92,7 +92,7 @@ class PlaceOS::Driver::Proxy::Driver
       end
 
       # Generate request body
-      request = PlaceOS::Driver::Proxy::Driver.__build_request__(function_name, function, arguments, named_args)
+      request = PlaceOS::Driver::Proxy::Driver.__build_request__(function_name, function, arguments, named_args, {name: @module_name, index: @index, id: @module_id})
 
       # Parse the execute response
       channel = PlaceOS::Driver::Protocol.instance.expect_response(@module_id, @reply_id, "exec", request, raw: true)
@@ -120,10 +120,11 @@ class PlaceOS::Driver::Proxy::Driver
 
   # Build the `exec` request payload
   protected def self.__build_request__(
-    function_name,
+    function_name : String,
     function,
     arguments,
-    named_args
+    named_args,
+    module_metadata : NamedTuple(name: String, index: Int32, id: String)
   )
     String.build do |str|
       str << %({"__exec__":") << function_name << %(",") << function_name << %(":{)
@@ -141,7 +142,7 @@ class PlaceOS::Driver::Proxy::Driver
                   elsif details.size > 1
                     details[1]
                   else
-                    raise "missing argument `#{arg_name} : #{details[0]}` for '#{function_name}' on #{@module_name}_#{@index} - #{@module_id}"
+                    raise "missing argument `#{arg_name} : #{details[0]}` for '#{function_name}' on #{module_metadata[:name]}_#{module_metadata[:index]} - #{module_metadata[:id]}"
                   end
                 end
 

--- a/src/placeos-driver/proxy/remote_driver.cr
+++ b/src/placeos-driver/proxy/remote_driver.cr
@@ -25,24 +25,23 @@ module PlaceOS::Driver::Proxy
       Admin
     end
 
-    @[Flags]
     enum ErrorCode
       # JSON parsing error
-      ParseError # 0
+      ParseError = 0
       # Pre-requisite does not exist (i.e no function)
-      BadRequest # 1
+      BadRequest = 1
       # The current user does not have permissions
-      AccessDenied # 2
+      AccessDenied = 2
       # The request was sent and error occured in core / the module
-      RequestFailed # 3
+      RequestFailed = 3
       # Not one of bind, unbind, exec, debug, ignore
-      UnknownCommand # 4
+      UnknownCommand = 4
       # System ID was not found in the database
-      SystemNotFound # 5
+      SystemNotFound = 5
       # Module does not exist in this system
-      ModuleNotFound # 6
+      ModuleNotFound = 6
       # Some other transient failure like database unavailable
-      UnexpectedFailure # 7
+      UnexpectedFailure = 7
 
       def to_s
         super.underscore


### PR DESCRIPTION
- `ErrorCode` enum was not utilising the `Flags` annotation
- extract exec payload generation into a class method to fix a complexity lint and make it easier to generate test exec payloads