### PR TITLE
feat(storage): share redis connection between all instances

### DIFF
--- a/src/placeos-driver/subscriptions.cr
+++ b/src/placeos-driver/subscriptions.cr
@@ -242,6 +242,9 @@ class PlaceOS::Driver
     @redis_cluster : Redis::Client? = nil
     @redis : Redis? = nil
 
+    # TODO:: we should look into using a shared client in the future
+    # this would require a decent re-factor however probably warrented
+    # and subscription callbacks could be delivered over channels
     protected def self.new_clustered_redis
       Redis::Client.boot(ENV["REDIS_URL"]? || "redis://localhost:6379")
     end


### PR DESCRIPTION
so we don't run out of connections - redis supports 10_000 by default, AWS redis supports 65_000

However a pool per-module instance is a bit much and should be per-driver

currently the exception to this is subscriptions but given the low number of drivers using subscriptions, this should not be a problem in the short term and we can re-evaluate this in the future

Left the interface as a lazy init to support edge core in the future
also didn't change the interface, just the internals