### PR TITLE
feat: bulk `ignore`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 4.1.3
+version: 4.2.0
 
 dependencies:
   action-controller:

--- a/spec/protocol_management_spec.cr
+++ b/spec/protocol_management_spec.cr
@@ -12,7 +12,7 @@ describe PlaceOS::Driver::Protocol::Management do
 
     # Called when the driver interacts with redis
     redis_callback = 0
-    manager.on_redis = ->(is_status : PlaceOS::Driver::Protocol::Management::RedisAction, module_id : String, key_name : String, status_value : String?) {
+    manager.on_redis = ->(_is_status : PlaceOS::Driver::Protocol::Management::RedisAction, _module_id : String, _key_name : String, _status_value : String?) {
       redis_callback += 1
     }
 

--- a/src/placeos-driver/protocol/management.cr
+++ b/src/placeos-driver/protocol/management.cr
@@ -402,7 +402,7 @@ class PlaceOS::Driver::Protocol::Management
         string = nil
         begin
           string = String.new(message[0..-3])
-          junk, _, string = string.rpartition(MESSAGE_INDICATOR)
+          _junk, _, string = string.rpartition(MESSAGE_INDICATOR)
 
           # Log.debug do
           #  if junk.empty?
@@ -434,6 +434,7 @@ class PlaceOS::Driver::Protocol::Management
   end
 
   # This function is used to process comms coming from the driver
+  # ameba:disable Metrics/CyclomaticComplexity
   private def process(request)
     case request.cmd
     when "start"

--- a/src/placeos-driver/protocol/management.cr
+++ b/src/placeos-driver/protocol/management.cr
@@ -458,7 +458,11 @@ class PlaceOS::Driver::Protocol::Management
       # pass the unparsed message down the pipe
       payload = request.payload.not_nil!
       watchers = debug_lock.synchronize { @debugging[request.id].dup }
-      watchers.each { |callback| callback.call(payload) }
+      watchers.each do |callback|
+        callback.call(payload)
+      rescue error
+        Log.warn(exception: error) { "error forwarding debug payload #{request.inspect}" }
+      end
     when "exec"
       # need to route this internally to the correct module
       on_exec.call(request, ->(response : Request) {


### PR DESCRIPTION
* Adds a method `PlaceOS::Driver::Protocol::Management#ignore_all(module_id : String) : Array(String -> Nil)` to remove all debug listeners on a module, returning the debug callbacks that were present.
* Prevents an exception raised in a debug callback from preventing forwarding debug messages to remaining callbacks
* Fixes a handful of ameba lints