### PR TITLE
fix: redundant log configuration

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 4.3.3
+version: 5.0.0
 
 dependencies:
   action-controller:
@@ -24,9 +24,6 @@ dependencies:
   promise:
     github: spider-gazelle/promise
 
-  protobuf:
-    github: jeromegn/protobuf.cr
-
   redis-cluster:
     github: caspiano/redis-cluster.cr
     version: ">= 0.8.4"
@@ -40,10 +37,13 @@ dependencies:
 
   tasker:
     github: spider-gazelle/tasker
+    version: ~> 2.0
 
   tokenizer:
     github: spider-gazelle/tokenizer
+    version: ~> 1.0
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+    version: ~> 0.14

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -229,9 +229,9 @@ abstract class PlaceOS::Driver
     {% klasses.map { |a| methods = methods + a.methods } %}
     {% methods = methods.reject { |method| RESERVED_METHODS[method.name.stringify] } %}
     {% methods = methods.reject { |method| method.visibility != :public } %}
-    {% methods = methods.reject { |method| method.accepts_block? } %}
+    {% methods = methods.reject &.accepts_block? %}
     # Filter out abstract methods
-    {% methods = methods.reject { |method| method.body.stringify.empty? } %}
+    {% methods = methods.reject &.body.stringify.empty? %}
 
     # A class that handles executing every public method defined
     # NOTE:: currently doesn't handle multiple methods signatures (except block
@@ -264,7 +264,7 @@ abstract class PlaceOS::Driver
 
               # Support argument lists
               if json.raw.is_a?(Array)
-                arg_names = { {{*args.map { |arg| arg.name.stringify }}} }
+                arg_names = { {{*args.map(&.name.stringify)}} }
                 args = json.as_a
 
                 raise "wrong number of arguments for '#{{{method.name.stringify}}}' (given #{args.size}, expected #{arg_names.size})" if args.size > arg_names.size

--- a/src/placeos-driver/driver-specs/mock_driver.cr
+++ b/src/placeos-driver/driver-specs/mock_driver.cr
@@ -111,9 +111,9 @@ abstract class DriverSpecs::MockDriver
     {% klasses.map { |a| methods = methods + a.methods } %}
     {% methods = methods.reject { |method| RESERVED_METHODS[method.name.stringify] } %}
     {% methods = methods.reject { |method| method.visibility != :public } %}
-    {% methods = methods.reject { |method| method.accepts_block? } %}
+    {% methods = methods.reject &.accepts_block? %}
     # Filter out abstract methods
-    {% methods = methods.reject { |method| method.body.stringify.empty? } %}
+    {% methods = methods.reject &.body.stringify.empty? %}
 
     class KlassExecutor < BaseExecutor
       EXECUTORS = {
@@ -132,7 +132,7 @@ abstract class DriverSpecs::MockDriver
 
               # Support argument lists
               if json.raw.is_a?(Array)
-                arg_names = { {{*args.map { |arg| arg.name.stringify }}} }
+                arg_names = { {{*args.map(&.name.stringify)}} }
                 args = json.as_a
 
                 raise "wrong number of arguments for '#{{{method.name.stringify}}}' (given #{args.size}, expected #{arg_names.size})" if args.size > arg_names.size

--- a/src/placeos-driver/exception.cr
+++ b/src/placeos-driver/exception.cr
@@ -1,9 +1,7 @@
 class PlaceOS::Driver::RemoteException < Exception
+  getter? backtrace
+
   def initialize(message, class_name, @backtrace = [] of String)
     @message = "#{message} (#{class_name})"
-  end
-
-  def backtrace?
-    @backtrace
   end
 end

--- a/src/placeos-driver/process_manager.cr
+++ b/src/placeos-driver/process_manager.cr
@@ -30,7 +30,8 @@ class PlaceOS::Driver::ProcessManager
   @edge_driver : Bool
   @input : IO
   @logger_io : IO
-  getter :loaded, terminated
+
+  getter loaded, terminated
 
   def start(request : Protocol::Request, driver_model = nil)
     module_id = request.id

--- a/src/placeos-driver/process_manager.cr
+++ b/src/placeos-driver/process_manager.cr
@@ -2,15 +2,11 @@ require "json"
 require "./logger"
 
 class PlaceOS::Driver::ProcessManager
-  Log = ::Log.for("driver.process_manager")
+  Log = ::Log.for("driver.process_manager", ::Log::Severity::Info)
 
   def initialize(@logger_io = ::PlaceOS::Driver.logger_io, @input = STDIN, output = STDERR, @edge_driver = false)
-    @subscriptions = @edge_driver ? nil : Subscriptions.new(@logger_io)
+    @subscriptions = @edge_driver ? nil : Subscriptions.new
     @protocol = PlaceOS::Driver::Protocol.new_instance(@input, output)
-
-    backend = ::Log::IOBackend.new(@logger_io)
-    backend.formatter = PlaceOS::Driver::LOG_FORMATTER
-    ::Log.builder.bind("driver.process_manager", ::Log::Severity::Info, backend)
     @protocol.register :start { |request| start(request) }
     @protocol.register :stop { |request| stop(request) }
     @protocol.register :update { |request| update(request) }

--- a/src/placeos-driver/process_manager.cr
+++ b/src/placeos-driver/process_manager.cr
@@ -11,9 +11,6 @@ class PlaceOS::Driver::ProcessManager
     backend = ::Log::IOBackend.new(@logger_io)
     backend.formatter = PlaceOS::Driver::LOG_FORMATTER
     ::Log.builder.bind("driver.process_manager", ::Log::Severity::Info, backend)
-
-    @loaded = {} of String => DriverManager
-
     @protocol.register :start { |request| start(request) }
     @protocol.register :stop { |request| stop(request) }
     @protocol.register :update { |request| update(request) }
@@ -22,24 +19,24 @@ class PlaceOS::Driver::ProcessManager
     @protocol.register :ignore { |request| ignore(request) }
     @protocol.register :info { |request| info(request) }
     @protocol.register :terminate { terminate }
-
-    @terminated = Channel(Nil).new
   end
 
-  @subscriptions : Subscriptions?
-  @edge_driver : Bool
-  @input : IO
-  @logger_io : IO
+  private getter input : IO
+  private getter logger_io : IO
 
-  getter loaded, terminated
+  private getter subscriptions : Subscriptions?
+  private getter? edge_driver : Bool
+
+  getter loaded : Hash(String, DriverManager) { {} of String => DriverManager }
+  getter terminated : Channel(Nil) { Channel(Nil).new }
 
   def start(request : Protocol::Request, driver_model = nil)
     module_id = request.id
-    return if @loaded[module_id]?
+    return if loaded[module_id]?
 
     model = driver_model || PlaceOS::Driver::DriverModel.from_json(request.payload.not_nil!)
-    driver = DriverManager.new module_id, model, @logger_io, @subscriptions, @edge_driver
-    @loaded[module_id] = driver
+    driver = DriverManager.new module_id, model, logger_io, @subscriptions, edge_driver?
+    loaded[module_id] = driver
 
     # Drivers can all run on a different thread
     spawn(same_thread: true) { driver.start }
@@ -52,7 +49,7 @@ class PlaceOS::Driver::ProcessManager
   end
 
   def stop(request : Protocol::Request) : Nil
-    driver = @loaded.delete request.id
+    driver = loaded.delete request.id
     if driver
       promise = Promise.new(Nil)
       driver.requests.send({promise, request})
@@ -62,7 +59,7 @@ class PlaceOS::Driver::ProcessManager
 
   def update(request : Protocol::Request) : Nil
     module_id = request.id
-    driver = @loaded[module_id]?
+    driver = loaded[module_id]?
     return unless driver
     existing = driver.model
     updated = PlaceOS::Driver::DriverModel.from_json(request.payload.not_nil!)
@@ -87,7 +84,7 @@ class PlaceOS::Driver::ProcessManager
   end
 
   def exec(request : Protocol::Request) : Protocol::Request
-    driver = @loaded[request.id]?
+    driver = loaded[request.id]?
 
     begin
       raise "driver not available" unless driver
@@ -105,39 +102,40 @@ class PlaceOS::Driver::ProcessManager
   end
 
   def debug(request : Protocol::Request) : Nil
-    driver = @loaded[request.id]?
+    driver = loaded[request.id]?
     driver.try &.logger.debugging = true
   end
 
   def ignore(request : Protocol::Request) : Nil
-    driver = @loaded[request.id]?
+    driver = loaded[request.id]?
     driver.try &.logger.debugging = false
   end
 
   def info(request : Protocol::Request) : Protocol::Request
-    request.payload = @loaded.keys.to_json
+    request.payload = loaded.keys.to_json
     request.cmd = "result"
     request
   end
 
   def terminate : Nil
     # Stop the core protocol handler (no more bets)
-    @input.close
+    input.close
 
     # Shutdown all the connections gracefully
     req = Protocol::Request.new("", "stop")
-    @loaded.each_value do |driver|
+    loaded.each_value do |driver|
       promise = Promise.new(Nil)
       driver.requests.send({promise, req})
       promise.get
     end
-    @loaded.clear
+
+    loaded.clear
 
     # We now want to stop the subscription loop
-    @subscriptions.try &.terminate
+    subscriptions.try &.terminate
 
     # TODO:: Wait until process have actually completed.
     # Also have a timer that will allow us to force close if required
-    @terminated.close
+    terminated.close
   end
 end

--- a/src/placeos-driver/proxy/system.cr
+++ b/src/placeos-driver/proxy/system.cr
@@ -175,17 +175,21 @@ class PlaceOS::Driver::Proxy::System
 
   # Returns a list of all the module names in the system
   def modules
-    @system.keys.map { |key| key.split("/")[0] }.uniq
+    module_keys.uniq!
   end
 
   # Grabs the number of a particular device type
   def count(module_name)
     module_name = module_name.to_s
-    @system.keys.map { |key| key.split("/")[0] }.count { |key| key == module_name }
+    module_keys.count { |key| key == module_name }
   end
 
   def id
     @system_id
+  end
+
+  private def module_keys
+    @system.keys.compact_map(&.split('/').first?)
   end
 
   private def get_parts(module_id)

--- a/src/placeos-driver/transport/http.cr
+++ b/src/placeos-driver/transport/http.cr
@@ -208,7 +208,7 @@ class PlaceOS::Driver
           query.split('&').map(&.split('=')).each { |part| params[part[0]] = part[1]? }
         end
 
-        uri.query = params.map { |key, value| value ? "#{key}=#{value}" : key }.join("&")
+        uri.query = params.join('&') { |key, value| value ? "#{key}=#{value}" : key }
       end
 
       # Apply a default fragment

--- a/src/placeos-driver/utilities/wake_on_lan.cr
+++ b/src/placeos-driver/utilities/wake_on_lan.cr
@@ -36,7 +36,7 @@ module PlaceOS::Driver::Utilities::WakeOnLAN
             raise "Unsupported subnet type: #{address.family} (#{address.family.value})"
           end
 
-    mac_address = mac_address.gsub(/(0x|[^0-9A-Fa-f])*/, "").scan(/.{2}/).map(&.[0]).join("")
+    mac_address = mac_address.gsub(/(0x|[^0-9A-Fa-f])*/, "").scan(/.{2}/).join("", &.[0])
     magicpacket = "ff" * 6 + mac_address * 16
 
     # The send methods may sporadically fail with Errno::ECONNREFUSED when sending datagrams to a non-listening server


### PR DESCRIPTION
`Log` was being configured at the instance level, at multiple sites.

Includes the cleanup of a handful of lints.