### PR TITLE
fix: sometimes the HTTP client lib does't decompress the response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - wget https://launchpad.net/ubuntu/+source/libssh2/1.8.0-2/+build/15151524/+files/libssh2-1-dev_1.8.0-2_amd64.deb
   - sudo dpkg -i libssh2-1-dev_1.8.0-2_amd64.deb
 
-  - shards install
+  - shards install --ignore-crystal-version
   - sleep 5
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ sudo: required
 services: redis-server
 
 install:
-  - docker pull placeos/ssh-test:latest
-  - docker run -d -p 2222:22 -e ROOT_PASS="somepassword" placeos/ssh-test:latest
-
   # Install the latest version of LibSSH2
   - wget https://launchpad.net/ubuntu/+source/libgpg-error/1.32-1/+build/15118612/+files/libgpg-error0_1.32-1_amd64.deb
   - sudo dpkg -i libgpg-error0_1.32-1_amd64.deb

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 5.0.2
+version: 5.0.3
 crystal: ">= 0.36.1"
 
 dependencies:

--- a/src/placeos-driver/driver_model.cr
+++ b/src/placeos-driver/driver_model.cr
@@ -55,5 +55,11 @@ struct PlaceOS::Driver::DriverModel
   property makebreak : Bool
   property uri : String?
   property settings : Hash(String, JSON::Any)
-  property role : Role
+
+  {% if compare_versions(Crystal::VERSION, "1.0.0") < 0 %}
+    @[JSON::Field(converter: Enum::ValueConverter(Role))]
+    property role : Role
+  {% else %}
+    property role : Role
+  {% end %}
 end

--- a/src/placeos-driver/logger.cr
+++ b/src/placeos-driver/logger.cr
@@ -41,9 +41,9 @@ class PlaceOS::Driver
     def write(entry : ::Log::Entry)
       if exception = entry.exception
         message = "#{entry.message}\n#{exception.inspect_with_backtrace}"
-        protocol.request entry.source, "debug", [entry.severity, message]
+        protocol.request entry.source, "debug", [entry.severity.to_i, message]
       else
-        protocol.request entry.source, "debug", [entry.severity, entry.message]
+        protocol.request entry.source, "debug", [entry.severity.to_i, entry.message]
       end
     end
   end

--- a/src/placeos-driver/transport.cr
+++ b/src/placeos-driver/transport.cr
@@ -66,14 +66,38 @@ abstract class PlaceOS::Driver::Transport
 
         # Make the request
         client = new_http_client(uri, context)
-        client.exec(method.to_s.upcase, uri.request_target, headers, body)
+        check_http_response_encoding client.exec(method.to_s.upcase, uri.request_target, headers, body)
       {% end %}
+    end
+
+    protected def check_http_response_encoding(response)
+      headers = response.headers
+      encoding = headers["Content-Encoding"]?
+      if encoding.in?({"gzip", "deflate"})
+        response.consume_body_io
+        body = response.body
+
+        if !body.blank?
+          body_io = IO::Memory.new(body)
+          body = case encoding
+                when "gzip"
+                  Compress::Gzip::Reader.open(body_io) { |gzip| gzip.gets_to_end }
+                when "deflate"
+                  Compress::Deflate::Reader.open(body_io) { |deflate| deflate.gets_to_end }
+                end
+
+          headers.delete("Content-Encoding")
+          headers.delete("Content-Length")
+
+          response = HTTP::Client::Response.new(response.status, body, headers, response.status_message, response.version)
+        end
+      end
+      response
     end
 
     {% if @type.name.stringify != "PlaceOS::Driver::TransportLogic" %}
       protected def new_http_client(uri, context)
         client = ConnectProxy::HTTPClient.new(uri, context, ignore_env: true)
-        client.compress = true
 
         # Apply basic auth settings
         if auth = @settings.get { setting?(NamedTuple(username: String, password: String), :basic_auth) }
@@ -96,6 +120,7 @@ abstract class PlaceOS::Driver::Transport
           end
         end
 
+        client.compress = true
         client
       end
     {% end %}

--- a/src/placeos-driver/transport.cr
+++ b/src/placeos-driver/transport.cr
@@ -80,11 +80,11 @@ abstract class PlaceOS::Driver::Transport
         if !body.blank?
           body_io = IO::Memory.new(body)
           body = case encoding
-                when "gzip"
-                  Compress::Gzip::Reader.open(body_io, &.gets_to_end)
-                when "deflate"
-                  Compress::Deflate::Reader.open(body_io, &.gets_to_end)
-                end
+                 when "gzip"
+                   Compress::Gzip::Reader.open(body_io, &.gets_to_end)
+                 when "deflate"
+                   Compress::Deflate::Reader.open(body_io, &.gets_to_end)
+                 end
 
           headers.delete("Content-Encoding")
           headers.delete("Content-Length")

--- a/src/placeos-driver/transport.cr
+++ b/src/placeos-driver/transport.cr
@@ -81,9 +81,9 @@ abstract class PlaceOS::Driver::Transport
           body_io = IO::Memory.new(body)
           body = case encoding
                 when "gzip"
-                  Compress::Gzip::Reader.open(body_io) { |gzip| gzip.gets_to_end }
+                  Compress::Gzip::Reader.open(body_io, &.gets_to_end)
                 when "deflate"
-                  Compress::Deflate::Reader.open(body_io) { |deflate| deflate.gets_to_end }
+                  Compress::Deflate::Reader.open(body_io, &.gets_to_end)
                 end
 
           headers.delete("Content-Encoding")


### PR DESCRIPTION
I assume this occurs when the body has not been completely sent when parsing the response. This ensures consistency when drivers are communicating over HTTP