### PR TITLE
fix(protocol/management): reentrant debug lock

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 5.0.7
+version: 5.0.8
 crystal: ">= 0.36.1"
 
 dependencies:

--- a/src/placeos-driver/protocol/management.cr
+++ b/src/placeos-driver/protocol/management.cr
@@ -38,7 +38,7 @@ class PlaceOS::Driver::Protocol::Management
 
   private getter tokenizer : Tokenizer = Tokenizer.new(Bytes[0x00, 0x03])
 
-  private getter debug_lock : Mutex = Mutex.new
+  private getter debug_lock : Mutex = Mutex.new(protection: :reentrant)
   private getter request_lock : Mutex = Mutex.new
   private getter settings_update_lock : Mutex = Mutex.new
 


### PR DESCRIPTION
Fixes a deadlock error when bulk ignoring debug callbacks on a running driver's protocol manager.