### PR TITLE
feat: add json schema to driver metadata

### DIFF
--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -21,6 +21,12 @@ class SchemaKlassNoRequired
   property other : Int32?
 end
 
+class RandomCustomKlass
+  def self.json_schema
+    { type: "object", require: ["something"] }
+  end
+end
+
 class SuperHash < Hash(String, Int32)
 end
 
@@ -111,6 +117,9 @@ describe PlaceOS::Driver::Settings do
     # test where no fields are required
     PlaceOS.introspect(NamedTuple(steve: String?)).should eq({type: "object", properties: {steve: {anyOf: [{type: "null"}, {type: "string"}]}}})
     PlaceOS.introspect(SchemaKlassNoRequired).should eq({type: "object", properties: {cmd: {anyOf: [{type: "null"}, {type: "string"}]}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}})
+
+    # allow totally custom classes to define their own schema
+    PlaceOS.introspect(RandomCustomKlass).should eq({ type: "object", require: ["something"] })
   end
 
   it "should generate JSON schema from settings access" do

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -1,5 +1,21 @@
 require "./helper"
 
+module AliasTest
+  alias Array = ::Array(String)
+end
+
+enum TestEnum
+  Bob
+  Jane
+end
+
+class SchemaKlass
+  include JSON::Serializable
+  property cmd : String
+end
+
+alias SomeType = Tuple(String, Bool) | String
+
 describe PlaceOS::Driver::Settings do
   it "should provide simplified access to settings" do
     settings = Helper.settings
@@ -57,5 +73,27 @@ describe PlaceOS::Driver::Settings do
 
     settings.raw?(:hash, :hello).should eq("world")
     settings.raw?(:hash, :no_exist).should eq(nil)
+  end
+
+  it "should generate JSON schema from objects" do
+    PlaceOS::Driver::Settings.introspect(Array(String)).should eq({type: "array", items: {type: "string"}})
+    PlaceOS::Driver::Settings.introspect(AliasTest::Array).should eq({type: "array", items: {type: "string"}})
+    PlaceOS::Driver::Settings.introspect(Array(Int32)).should eq({type: "array", items: {type: "integer"}})
+    PlaceOS::Driver::Settings.introspect(Array(Float32)).should eq({type: "array", items: {type: "number"}})
+    PlaceOS::Driver::Settings.introspect(Array(Bool)).should eq({type: "array", items: {type: "boolean"}})
+    PlaceOS::Driver::Settings.introspect(Array(JSON::Any)).should eq({type: "array"})
+    PlaceOS::Driver::Settings.introspect(NamedTuple(steve: String)).should eq({type: "object", properties: {steve: {type: "string"}}, required: ["steve"]})
+    PlaceOS::Driver::Settings.introspect(TestEnum).should eq({type: "string", enum: ["Bob", "Jane"]})
+    PlaceOS::Driver::Settings.introspect(Tuple(String, Bool)).should eq({type: "array", items: [{type: "string"}, {type: "boolean"}]})
+    PlaceOS::Driver::Settings.introspect(SomeType).should eq({anyOf: [
+      {type: "string"},
+      {type: "array", items: [{type: "string"}, {type: "boolean"}]}
+    ]})
+    PlaceOS::Driver::Settings.introspect(Bool | String).should eq({anyOf: [{type: "boolean"}, {type: "string"}]})
+    PlaceOS::Driver::Settings.introspect(SchemaKlass).should eq({type: "object"})
+  end
+
+  it "should generate JSON schema from settings access" do
+    PlaceOS::Driver::Settings.get { generate_json_schema }.starts_with?(%({"type":"object","properties":{)).should be_true
   end
 end

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -23,7 +23,7 @@ end
 
 class RandomCustomKlass
   def self.json_schema
-    { type: "object", require: ["something"] }
+    {type: "object", require: ["something"]}
   end
 end
 
@@ -119,7 +119,7 @@ describe PlaceOS::Driver::Settings do
     PlaceOS.introspect(SchemaKlassNoRequired).should eq({type: "object", properties: {cmd: {anyOf: [{type: "null"}, {type: "string"}]}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}})
 
     # allow totally custom classes to define their own schema
-    PlaceOS.introspect(RandomCustomKlass).should eq({ type: "object", require: ["something"] })
+    PlaceOS.introspect(RandomCustomKlass).should eq({type: "object", require: ["something"]})
   end
 
   it "should generate JSON schema from settings access" do

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -87,7 +87,7 @@ describe PlaceOS::Driver::Settings do
     PlaceOS::Driver::Settings.introspect(Tuple(String, Bool)).should eq({type: "array", items: [{type: "string"}, {type: "boolean"}]})
     PlaceOS::Driver::Settings.introspect(SomeType).should eq({anyOf: [
       {type: "string"},
-      {type: "array", items: [{type: "string"}, {type: "boolean"}]}
+      {type: "array", items: [{type: "string"}, {type: "boolean"}]},
     ]})
     PlaceOS::Driver::Settings.introspect(Bool | String).should eq({anyOf: [{type: "boolean"}, {type: "string"}]})
     PlaceOS::Driver::Settings.introspect(SchemaKlass).should eq({type: "object"})

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -119,7 +119,7 @@ describe PlaceOS::Driver::Settings do
     PlaceOS.introspect(SchemaKlassNoRequired).should eq({type: "object", properties: {cmd: {anyOf: [{type: "null"}, {type: "string"}]}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}})
 
     # allow totally custom classes to define their own schema
-    PlaceOS.introspect(RandomCustomKlass).should eq({type: "object", require: ["something"]})
+    PlaceOS.introspect(RandomCustomKlass).should eq({type: "object", required: ["something"]})
   end
 
   it "should generate JSON schema from settings access" do

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -95,31 +95,31 @@ describe PlaceOS::Driver::Settings do
   end
 
   it "should generate JSON schema from objects" do
-    PlaceOS.introspect(Array(String)).should eq({type: "array", items: {type: "string"}})
-    PlaceOS.introspect(SuperArray).should eq({type: "array"})
-    PlaceOS.introspect(AliasTest::Array).should eq({type: "array", items: {type: "string"}})
-    PlaceOS.introspect(Array(Int32)).should eq({type: "array", items: {type: "integer"}})
-    PlaceOS.introspect(Array(Float32)).should eq({type: "array", items: {type: "number"}})
-    PlaceOS.introspect(Array(Bool)).should eq({type: "array", items: {type: "boolean"}})
-    PlaceOS.introspect(Array(JSON::Any)).should eq({type: "array"})
-    PlaceOS.introspect(NamedTuple(steve: String)).should eq({type: "object", properties: {steve: {type: "string"}}, required: ["steve"]})
-    PlaceOS.introspect(TestEnum).should eq({type: "string", enum: ["Bob", "Jane"]})
-    PlaceOS.introspect(Tuple(String, Bool)).should eq({type: "array", items: [{type: "string"}, {type: "boolean"}]})
-    PlaceOS.introspect(SomeType).should eq({anyOf: [
+    PlaceOS::Driver::Settings.introspect(Array(String)).should eq({type: "array", items: {type: "string"}})
+    PlaceOS::Driver::Settings.introspect(SuperArray).should eq({type: "array"})
+    PlaceOS::Driver::Settings.introspect(AliasTest::Array).should eq({type: "array", items: {type: "string"}})
+    PlaceOS::Driver::Settings.introspect(Array(Int32)).should eq({type: "array", items: {type: "integer"}})
+    PlaceOS::Driver::Settings.introspect(Array(Float32)).should eq({type: "array", items: {type: "number"}})
+    PlaceOS::Driver::Settings.introspect(Array(Bool)).should eq({type: "array", items: {type: "boolean"}})
+    PlaceOS::Driver::Settings.introspect(Array(JSON::Any)).should eq({type: "array"})
+    PlaceOS::Driver::Settings.introspect(NamedTuple(steve: String)).should eq({type: "object", properties: {steve: {type: "string"}}, required: ["steve"]})
+    PlaceOS::Driver::Settings.introspect(TestEnum).should eq({type: "string", enum: ["Bob", "Jane"]})
+    PlaceOS::Driver::Settings.introspect(Tuple(String, Bool)).should eq({type: "array", items: [{type: "string"}, {type: "boolean"}]})
+    PlaceOS::Driver::Settings.introspect(SomeType).should eq({anyOf: [
       {type: "string"},
       {type: "array", items: [{type: "string"}, {type: "boolean"}]},
     ]})
-    PlaceOS.introspect(Hash(String, Int32)).should eq({type: "object", additionalProperties: {type: "integer"}})
-    PlaceOS.introspect(SuperHash).should eq({type: "object"})
-    PlaceOS.introspect(Bool | String).should eq({anyOf: [{type: "boolean"}, {type: "string"}]})
-    PlaceOS.introspect(SchemaKlass).should eq({type: "object", properties: {cmd: {type: "string"}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}, required: ["cmd"]})
+    PlaceOS::Driver::Settings.introspect(Hash(String, Int32)).should eq({type: "object", additionalProperties: {type: "integer"}})
+    PlaceOS::Driver::Settings.introspect(SuperHash).should eq({type: "object"})
+    PlaceOS::Driver::Settings.introspect(Bool | String).should eq({anyOf: [{type: "boolean"}, {type: "string"}]})
+    PlaceOS::Driver::Settings.introspect(SchemaKlass).should eq({type: "object", properties: {cmd: {type: "string"}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}, required: ["cmd"]})
 
     # test where no fields are required
-    PlaceOS.introspect(NamedTuple(steve: String?)).should eq({type: "object", properties: {steve: {anyOf: [{type: "null"}, {type: "string"}]}}})
-    PlaceOS.introspect(SchemaKlassNoRequired).should eq({type: "object", properties: {cmd: {anyOf: [{type: "null"}, {type: "string"}]}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}})
+    PlaceOS::Driver::Settings.introspect(NamedTuple(steve: String?)).should eq({type: "object", properties: {steve: {anyOf: [{type: "null"}, {type: "string"}]}}})
+    PlaceOS::Driver::Settings.introspect(SchemaKlassNoRequired).should eq({type: "object", properties: {cmd: {anyOf: [{type: "null"}, {type: "string"}]}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}})
 
     # allow totally custom classes to define their own schema
-    PlaceOS.introspect(RandomCustomKlass).should eq({type: "object", required: ["something"]})
+    PlaceOS::Driver::Settings.introspect(RandomCustomKlass).should eq({type: "object", required: ["something"]})
   end
 
   it "should generate JSON schema from settings access" do

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -89,6 +89,7 @@ describe PlaceOS::Driver::Settings do
       {type: "string"},
       {type: "array", items: [{type: "string"}, {type: "boolean"}]},
     ]})
+    PlaceOS::Driver::Settings.introspect(Hash(String, Int32)).should eq({type: "object", additionalProperties: {type: "integer"}})
     PlaceOS::Driver::Settings.introspect(Bool | String).should eq({anyOf: [{type: "boolean"}, {type: "string"}]})
     PlaceOS::Driver::Settings.introspect(SchemaKlass).should eq({type: "object"})
   end

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -12,6 +12,7 @@ end
 class SchemaKlass
   include JSON::Serializable
   property cmd : String
+  property other : Int32?
 end
 
 alias SomeType = Tuple(String, Bool) | String
@@ -76,22 +77,22 @@ describe PlaceOS::Driver::Settings do
   end
 
   it "should generate JSON schema from objects" do
-    PlaceOS::Driver::Settings.introspect(Array(String)).should eq({type: "array", items: {type: "string"}})
-    PlaceOS::Driver::Settings.introspect(AliasTest::Array).should eq({type: "array", items: {type: "string"}})
-    PlaceOS::Driver::Settings.introspect(Array(Int32)).should eq({type: "array", items: {type: "integer"}})
-    PlaceOS::Driver::Settings.introspect(Array(Float32)).should eq({type: "array", items: {type: "number"}})
-    PlaceOS::Driver::Settings.introspect(Array(Bool)).should eq({type: "array", items: {type: "boolean"}})
-    PlaceOS::Driver::Settings.introspect(Array(JSON::Any)).should eq({type: "array"})
-    PlaceOS::Driver::Settings.introspect(NamedTuple(steve: String)).should eq({type: "object", properties: {steve: {type: "string"}}, required: ["steve"]})
-    PlaceOS::Driver::Settings.introspect(TestEnum).should eq({type: "string", enum: ["Bob", "Jane"]})
-    PlaceOS::Driver::Settings.introspect(Tuple(String, Bool)).should eq({type: "array", items: [{type: "string"}, {type: "boolean"}]})
-    PlaceOS::Driver::Settings.introspect(SomeType).should eq({anyOf: [
+    PlaceOS.introspect(Array(String)).should eq({type: "array", items: {type: "string"}})
+    PlaceOS.introspect(AliasTest::Array).should eq({type: "array", items: {type: "string"}})
+    PlaceOS.introspect(Array(Int32)).should eq({type: "array", items: {type: "integer"}})
+    PlaceOS.introspect(Array(Float32)).should eq({type: "array", items: {type: "number"}})
+    PlaceOS.introspect(Array(Bool)).should eq({type: "array", items: {type: "boolean"}})
+    PlaceOS.introspect(Array(JSON::Any)).should eq({type: "array"})
+    PlaceOS.introspect(NamedTuple(steve: String)).should eq({type: "object", properties: {steve: {type: "string"}}, required: ["steve"]})
+    PlaceOS.introspect(TestEnum).should eq({type: "string", enum: ["Bob", "Jane"]})
+    PlaceOS.introspect(Tuple(String, Bool)).should eq({type: "array", items: [{type: "string"}, {type: "boolean"}]})
+    PlaceOS.introspect(SomeType).should eq({anyOf: [
       {type: "string"},
       {type: "array", items: [{type: "string"}, {type: "boolean"}]},
     ]})
-    PlaceOS::Driver::Settings.introspect(Hash(String, Int32)).should eq({type: "object", additionalProperties: {type: "integer"}})
-    PlaceOS::Driver::Settings.introspect(Bool | String).should eq({anyOf: [{type: "boolean"}, {type: "string"}]})
-    PlaceOS::Driver::Settings.introspect(SchemaKlass).should eq({type: "object"})
+    PlaceOS.introspect(Hash(String, Int32)).should eq({type: "object", additionalProperties: {type: "integer"}})
+    PlaceOS.introspect(Bool | String).should eq({anyOf: [{type: "boolean"}, {type: "string"}]})
+    PlaceOS.introspect(SchemaKlass).should eq({type: "object", properties: {cmd: {type: "string"}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}, required: ["cmd"]})
   end
 
   it "should generate JSON schema from settings access" do

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -15,6 +15,12 @@ class SchemaKlass
   property other : Int32?
 end
 
+class SuperHash < Hash(String, Int32)
+end
+
+class SuperArray < Array(Int32)
+end
+
 alias SomeType = Tuple(String, Bool) | String
 
 describe PlaceOS::Driver::Settings do
@@ -78,6 +84,7 @@ describe PlaceOS::Driver::Settings do
 
   it "should generate JSON schema from objects" do
     PlaceOS.introspect(Array(String)).should eq({type: "array", items: {type: "string"}})
+    PlaceOS.introspect(SuperArray).should eq({type: "array"})
     PlaceOS.introspect(AliasTest::Array).should eq({type: "array", items: {type: "string"}})
     PlaceOS.introspect(Array(Int32)).should eq({type: "array", items: {type: "integer"}})
     PlaceOS.introspect(Array(Float32)).should eq({type: "array", items: {type: "number"}})
@@ -91,6 +98,7 @@ describe PlaceOS::Driver::Settings do
       {type: "array", items: [{type: "string"}, {type: "boolean"}]},
     ]})
     PlaceOS.introspect(Hash(String, Int32)).should eq({type: "object", additionalProperties: {type: "integer"}})
+    PlaceOS.introspect(SuperHash).should eq({type: "object"})
     PlaceOS.introspect(Bool | String).should eq({anyOf: [{type: "boolean"}, {type: "string"}]})
     PlaceOS.introspect(SchemaKlass).should eq({type: "object", properties: {cmd: {type: "string"}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}, required: ["cmd"]})
   end

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -23,7 +23,7 @@ end
 
 class RandomCustomKlass
   def self.json_schema
-    {type: "object", require: ["something"]}
+    {type: "object", required: ["something"]}
   end
 end
 

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -15,6 +15,12 @@ class SchemaKlass
   property other : Int32?
 end
 
+class SchemaKlassNoRequired
+  include JSON::Serializable
+  property cmd : String?
+  property other : Int32?
+end
+
 class SuperHash < Hash(String, Int32)
 end
 
@@ -101,6 +107,10 @@ describe PlaceOS::Driver::Settings do
     PlaceOS.introspect(SuperHash).should eq({type: "object"})
     PlaceOS.introspect(Bool | String).should eq({anyOf: [{type: "boolean"}, {type: "string"}]})
     PlaceOS.introspect(SchemaKlass).should eq({type: "object", properties: {cmd: {type: "string"}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}, required: ["cmd"]})
+
+    # test where no fields are required
+    PlaceOS.introspect(NamedTuple(steve: String?)).should eq({type: "object", properties: {steve: {anyOf: [{type: "null"}, {type: "string"}]}}})
+    PlaceOS.introspect(SchemaKlassNoRequired).should eq({type: "object", properties: {cmd: {anyOf: [{type: "null"}, {type: "string"}]}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}})
   end
 
   it "should generate JSON schema from settings access" do

--- a/spec/test_build.cr
+++ b/spec/test_build.cr
@@ -32,6 +32,15 @@ class Helper
       },
     })
 
+    def on_load
+      @username = setting(String, :username)
+      @password = setting?(String, :password) || ""
+    rescue
+    end
+
+    @username : String = ""
+    @password : String = ""
+
     accessor thing : Thing, implementing: IncludedAble
     accessor main_lcd : Display_1, implementing: Powerable
     accessor switcher : Switcher

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -405,11 +405,14 @@ abstract class PlaceOS::Driver
         return metadata if metadata
 
         implements = {{@type.ancestors.map(&.stringify.split("(")[0])}}.reject { |obj| IGNORE_KLASSES.includes?(obj) }
+        schema = PlaceOS::Driver::Settings.get { generate_json_schema }
+
         details = %({
           "functions": #{self.functions},
           "implements": #{implements.to_json},
           "requirements": #{Utilities::Discovery.requirements.to_json},
-          "security": #{self.security}
+          "security": #{self.security},
+          "settings": #{schema}
         }).gsub(/\s/, "")
 
         @@metadata = details

--- a/src/placeos-driver/driver_model.cr
+++ b/src/placeos-driver/driver_model.cr
@@ -39,7 +39,7 @@ struct PlaceOS::Driver::DriverModel
     # Function access control, map of access level to function names
     property security : Hash(String, Array(String))
     # JSON Schema derived from the settings used in the driver
-    property settings : NamedTuple(type: String, properties: Hash(String, JSON::Any)?, required: Array(String)?)
+    property settings : NamedTuple(type: String, properties: Hash(String, JSON::Any)?, required: Array(String)?)?
   end
 
   enum Role

--- a/src/placeos-driver/driver_model.cr
+++ b/src/placeos-driver/driver_model.cr
@@ -25,7 +25,8 @@ struct PlaceOS::Driver::DriverModel
       @functions = {} of String => Hash(String, Array(JSON::Any)),
       @implements = [] of String,
       @requirements = {} of String => Array(String),
-      @security = {} of String => Array(String)
+      @security = {} of String => Array(String),
+      @settings = {type: "object", properties: {} of String => JSON::Any, required: [] of String}
     )
     end
 
@@ -37,6 +38,8 @@ struct PlaceOS::Driver::DriverModel
     property requirements : Hash(String, Array(String))
     # Function access control, map of access level to function names
     property security : Hash(String, Array(String))
+    # JSON Schema derived from the settings used in the driver
+    property settings : NamedTuple(type: String, properties: Hash(String, JSON::Any)?, required: Array(String)?)
   end
 
   enum Role

--- a/src/placeos-driver/settings.cr
+++ b/src/placeos-driver/settings.cr
@@ -186,7 +186,7 @@ class PlaceOS::Driver::Settings
       {% elsif klass <= Float %}
         { type: "number" }
       {% elsif klass <= Hash %}
-        { type: "object" }
+        { type: "object", additionalProperties: PlaceOS::Driver::Settings.introspect({{klass.type_vars[1]}}) }
       {% elsif klass.ancestors.includes? JSON::Serializable %}
         # TODO:: would like to improve on this, but it's challenging
         {type: "object"}

--- a/src/placeos-driver/settings.cr
+++ b/src/placeos-driver/settings.cr
@@ -46,7 +46,6 @@ class PlaceOS::Driver::Settings
     # We check for key size == 1 as hard to build schema for sub keys
     # this won't prevent the setting from working, just not part of the schema
     {% if keys.size == 1 %}
-      {% puts "\n\nADDING SETTING #{keys[0]}\n" %}
       {% ::PlaceOS::SETTINGS_REQ[keys[0]] = {klass, true} %}
     {% end %}
     %keys = {{keys}}.map &.to_s
@@ -65,8 +64,7 @@ class PlaceOS::Driver::Settings
 
   macro setting?(klass, *keys)
     {% if keys.size == 1 %}
-      {% puts "\n\nADDING SETTING #{keys[0]}\n" %}
-      {% ::PlaceOS::SETTINGS_REQ[keys[0]] = {klass, true} %}
+      {% ::PlaceOS::SETTINGS_REQ[keys[0]] = {klass, false} %}
     {% end %}
     %keys = {{keys}}.map &.to_s
     %json = json.dig?(*%keys)
@@ -200,7 +198,6 @@ class PlaceOS::Driver::Settings
   end
 
   macro generate_json_schema
-    {% puts "\n\nGENERATING SCHEMA #{::PlaceOS::SETTINGS_REQ.size}\n" %}
     {
       type: "object",
       {% if !::PlaceOS::SETTINGS_REQ.empty? %}

--- a/src/placeos-driver/settings.cr
+++ b/src/placeos-driver/settings.cr
@@ -1,5 +1,3 @@
-require "./settings/introspect"
-
 class PlaceOS::Driver::Settings
   def initialize(settings : String)
     @json = JSON.parse(settings).as_h
@@ -43,7 +41,7 @@ class PlaceOS::Driver::Settings
       PlaceOS::Driver::Settings.add_setting_key(key, Union({{klass}}), {{required}})
     {% else %}
       {% klass = klass.resolve %}
-      {% ::PlaceOS::SETTINGS_REQ[key] = {klass, required} %}
+      {% ::PlaceOS::Driver::Settings::SETTINGS_REQ[key] = {klass, required} %}
     {% end %}
   end
 
@@ -143,15 +141,15 @@ class PlaceOS::Driver::Settings
   macro generate_json_schema
     {
       type: "object",
-      {% if !::PlaceOS::SETTINGS_REQ.empty? %}
+      {% if !::PlaceOS::Driver::Settings::SETTINGS_REQ.empty? %}
         properties: {
-          {% for key, details in ::PlaceOS::SETTINGS_REQ %}
+          {% for key, details in ::PlaceOS::Driver::Settings::SETTINGS_REQ %}
             {% klass = details[0] %}
-            {{key.id}}: PlaceOS.introspect({{klass}}),
+            {{key.id}}: PlaceOS::Driver::Settings.introspect({{klass}}),
           {% end %}
         },
         required: [
-          {% for key, details in ::PlaceOS::SETTINGS_REQ %}
+          {% for key, details in ::PlaceOS::Driver::Settings::SETTINGS_REQ %}
             {% required = details[1] %}
             {% if required %}
               {{key.id.stringify}},
@@ -162,3 +160,5 @@ class PlaceOS::Driver::Settings
     }.to_json
   end
 end
+
+require "./settings/introspect"

--- a/src/placeos-driver/settings/introspect.cr
+++ b/src/placeos-driver/settings/introspect.cr
@@ -25,7 +25,7 @@ module PlaceOS
           },
             {% required = [] of String %}
             {% for key, ivar in properties %}
-              {% if !ivar.nilable? %}
+              {% unless ivar.nilable? %}
                 {% required << key.stringify %}
               {% end %}
             {% end %}

--- a/src/placeos-driver/settings/introspect.cr
+++ b/src/placeos-driver/settings/introspect.cr
@@ -29,7 +29,7 @@ module PlaceOS
                 {% required << key.stringify %}
               {% end %}
             {% end %}
-            {% if !required.empty? %}
+            {% unless required.empty? %}
               required: [
               {% for key in required %}
                 {{key}},

--- a/src/placeos-driver/settings/introspect.cr
+++ b/src/placeos-driver/settings/introspect.cr
@@ -49,7 +49,11 @@ module PlaceOS
       {% klass_name = klass.name(generic_args: false) %}
 
       {% if klass <= Array %}
-        has_items = PlaceOS.introspect {{klass.type_vars[0]}}
+        {% if klass.type_vars.size == 1 %}
+          has_items = PlaceOS.introspect {{klass.type_vars[0]}}
+        {% else %}
+          has_items = {} of String => String
+        {% end %}
         if has_items.empty?
           {type: "array"}
         else
@@ -93,7 +97,12 @@ module PlaceOS
       {% elsif klass <= Nil %}
         { type: "null" }
       {% elsif klass <= Hash %}
-        { type: "object", additionalProperties: PlaceOS.introspect({{klass.type_vars[1]}}) }
+        {% if klass.type_vars.size == 2 %}
+          { type: "object", additionalProperties: PlaceOS.introspect({{klass.type_vars[1]}}) }
+        {% else %}
+          # As inheritance might include the type_vars it's hard to work them out
+          { type: "object" }
+        {% end %}
       {% elsif klass.ancestors.includes? JSON::Serializable %}
         {{klass}}.__generate_json_schema__
       {% else %}

--- a/src/placeos-driver/settings/introspect.cr
+++ b/src/placeos-driver/settings/introspect.cr
@@ -1,0 +1,105 @@
+require "json"
+
+module PlaceOS
+  # key => {class, required}
+  SETTINGS_REQ = {} of Nil => Nil
+
+  module Introspect
+    def __generate_json_schema__
+      {% begin %}
+        {% properties = {} of Nil => Nil %}
+        {% for ivar in @type.instance_vars %}
+          {% ann = ivar.annotation(::JSON::Field) %}
+          {% unless ann && (ann[:ignore] || ann[:ignore_deserialize]) %}
+            {% properties[((ann && ann[:key]) || ivar).id] = ivar.type %}
+          {% end %}
+        {% end %}
+
+        {% if properties.empty? %}
+          { type: "object" }
+        {% else %}
+          {type: "object",  properties: {
+            {% for key, ivar in properties %}
+              {{key}}: PlaceOS.introspect({{ivar.resolve.name}}),
+            {% end %}
+          }, required: [
+            {% for key, ivar in properties %}
+              {% if !ivar.nilable? %}
+                {{key.stringify}},
+              {% end %}
+            {% end %}
+          ] of String}
+        {% end %}
+      {% end %}
+    end
+  end
+
+  module ::JSON::Serializable
+    macro included
+      extend ::PlaceOS::Introspect
+    end
+  end
+
+  macro introspect(klass)
+    {% arg_name = klass.stringify %}
+    {% if !arg_name.starts_with?("Union") && arg_name.includes?("|") %}
+      PlaceOS.introspect(Union({{klass}}))
+    {% else %}
+      {% klass = klass.resolve %}
+      {% klass_name = klass.name(generic_args: false) %}
+
+      {% if klass <= Array %}
+        has_items = PlaceOS.introspect {{klass.type_vars[0]}}
+        if has_items.empty?
+          {type: "array"}
+        else
+          {type: "array", items: has_items}
+        end
+      {% elsif klass.union? %}
+        { anyOf: [
+          {% for type in klass.union_types %}
+            PlaceOS.introspect({{type}}),
+          {% end %}
+        ]}
+      {% elsif klass_name.starts_with? "Tuple(" %}
+        has_items = [
+          {% for generic in klass.type_vars %}
+            PlaceOS.introspect({{generic}}),
+          {% end %}
+        ]
+        {type: "array", items: has_items}
+      {% elsif klass_name.starts_with? "NamedTuple(" %}
+        {type: "object",  properties: {
+          {% for key in klass.keys %}
+            {{key.id}}: PlaceOS.introspect({{klass[key].resolve.name}}),
+          {% end %}
+        }, required: [
+          {% for key in klass.keys %}
+            {% if !klass[key].resolve.nilable? %}
+              {{key.id.stringify}},
+            {% end %}
+          {% end %}
+        ] of String}
+      {% elsif klass < Enum %}
+        {type: "string",  enum: {{klass.constants.map(&.stringify)}} }
+      {% elsif klass <= String %}
+        { type: "string" }
+      {% elsif klass <= Bool %}
+        { type: "boolean" }
+      {% elsif klass <= Int %}
+        { type: "integer" }
+      {% elsif klass <= Float %}
+        { type: "number" }
+      {% elsif klass <= Nil %}
+        { type: "null" }
+      {% elsif klass <= Hash %}
+        { type: "object", additionalProperties: PlaceOS.introspect({{klass.type_vars[1]}}) }
+      {% elsif klass.ancestors.includes? JSON::Serializable %}
+        {{klass}}.__generate_json_schema__
+      {% else %}
+        # anything will validate (JSON::Any)
+        {} of String => String
+      {% end %}
+    {% end %}
+  end
+end

--- a/src/placeos-driver/settings/introspect.cr
+++ b/src/placeos-driver/settings/introspect.cr
@@ -22,13 +22,21 @@ module PlaceOS
             {% for key, ivar in properties %}
               {{key}}: PlaceOS.introspect({{ivar.resolve.name}}),
             {% end %}
-          }, required: [
+          },
+            {% required = [] of String %}
             {% for key, ivar in properties %}
               {% if !ivar.nilable? %}
-                {{key.stringify}},
+                {% required << key.stringify %}
               {% end %}
             {% end %}
-          ] of String}
+            {% if !required.empty? %}
+              required: [
+              {% for key in required %}
+                {{key}},
+              {% end %}
+              ]
+            {% end %}
+          }
         {% end %}
       {% end %}
     end
@@ -77,13 +85,21 @@ module PlaceOS
           {% for key in klass.keys %}
             {{key.id}}: PlaceOS.introspect({{klass[key].resolve.name}}),
           {% end %}
-        }, required: [
+        },
+          {% required = [] of String %}
           {% for key in klass.keys %}
             {% if !klass[key].resolve.nilable? %}
-              {{key.id.stringify}},
+              {% required << key.id.stringify %}
             {% end %}
           {% end %}
-        ] of String}
+          {% if !required.empty? %}
+            required: [
+            {% for key in required %}
+              {{key}},
+            {% end %}
+            ]
+          {% end %}
+        }
       {% elsif klass < Enum %}
         {type: "string",  enum: {{klass.constants.map(&.stringify)}} }
       {% elsif klass <= String %}

--- a/src/placeos-driver/settings/introspect.cr
+++ b/src/placeos-driver/settings/introspect.cr
@@ -63,7 +63,8 @@ module PlaceOS
           has_items = {} of String => String
         {% end %}
         if has_items.empty?
-          {type: "array"}
+          %klass = {{klass}}
+          %klass.responds_to?(:json_schema) ? %klass.json_schema : {type: "array"}
         else
           {type: "array", items: has_items}
         end
@@ -117,13 +118,19 @@ module PlaceOS
           { type: "object", additionalProperties: PlaceOS.introspect({{klass.type_vars[1]}}) }
         {% else %}
           # As inheritance might include the type_vars it's hard to work them out
-          { type: "object" }
+          %klass = {{klass}}
+          %klass.responds_to?(:json_schema) ? %klass.json_schema : { type: "object" }
         {% end %}
       {% elsif klass.ancestors.includes? JSON::Serializable %}
         {{klass}}.__generate_json_schema__
       {% else %}
-        # anything will validate (JSON::Any)
-        {} of String => String
+        %klass = {{klass}}
+        if %klass.responds_to?(:json_schema)
+          %klass.json_schema
+        else
+          # anything will validate (JSON::Any)
+          {} of String => String
+        end
       {% end %}
     {% end %}
   end

--- a/src/placeos-driver/transport/ssh.cr
+++ b/src/placeos-driver/transport/ssh.cr
@@ -67,8 +67,8 @@ class PlaceOS::Driver
         supported_methods = nil
 
         begin
-          # Grab the authentication settings
-          settings = @settings.get { setting(Settings, :ssh) }
+          # Grab the authentication settings (using not_nil for schema generation)
+          settings = @settings.get { setting?(Settings, :ssh) }.not_nil!
 
           # Open a connection
           socket = TCPSocket.new(@ip, @port, connect_timeout: connect_timeout)

--- a/src/placeos-driver/transport/ssh.cr
+++ b/src/placeos-driver/transport/ssh.cr
@@ -68,7 +68,7 @@ class PlaceOS::Driver
 
         begin
           # Grab the authentication settings (using not_nil for schema generation)
-          settings = @settings.get { setting?(PlaceOS::Driver::TransportSSH::Settings, :ssh) }.not_nil!
+          settings = @settings.get { setting?(Settings, :ssh) }.not_nil!
 
           # Open a connection
           socket = TCPSocket.new(@ip, @port, connect_timeout: connect_timeout)

--- a/src/placeos-driver/transport/ssh.cr
+++ b/src/placeos-driver/transport/ssh.cr
@@ -68,7 +68,7 @@ class PlaceOS::Driver
 
         begin
           # Grab the authentication settings (using not_nil for schema generation)
-          settings = @settings.get { setting?(Settings, :ssh) }.not_nil!
+          settings = @settings.get { setting?(PlaceOS::Driver::TransportSSH::Settings, :ssh) }.not_nil!
 
           # Open a connection
           socket = TCPSocket.new(@ip, @port, connect_timeout: connect_timeout)

--- a/src/placeos-driver/utilities/discovery.cr
+++ b/src/placeos-driver/utilities/discovery.cr
@@ -105,7 +105,7 @@ abstract class PlaceOS::Driver
       {% if compiler_enforced %}
         {% methods = methods.reject { |method| RESERVED_METHODS[method.name.stringify] } %}
         {% methods = methods.reject { |method| method.visibility != :public } %}
-        {% methods = methods.reject { |method| method.accepts_block? } %}
+        {% methods = methods.reject(&.accepts_block?) %}
       {% else %}
         {% methods = [] of Crystal::Macros::TypeNode %}
       {% end %}


### PR DESCRIPTION
generates this based on the extraction of settings fixes PlaceOS/rest-api#114

Existing limitations:
* settings can technically extract sub keys `setting(String, :base, :subkey)` and these are ignored due to complexity

I don't think any driver is using sub keys at this time