### PR TITLE
refactor(storage): stop extending stdlib hash

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 5.0.10
+version: 5.1.0
 crystal: ">= 0.36.1"
 
 dependencies:

--- a/src/placeos-driver/status.cr
+++ b/src/placeos-driver/status.cr
@@ -1,4 +1,7 @@
-class PlaceOS::Driver::Status < Hash(String, String)
+class PlaceOS::Driver::Status
+  private getter hash : Hash(String, String) = {} of String => String
+  forward_missing_to hash
+
   def set_json(key, value)
     key = key.to_s
     current_value = self[key]?

--- a/src/placeos-driver/status.cr
+++ b/src/placeos-driver/status.cr
@@ -1,5 +1,5 @@
 class PlaceOS::Driver::Status
-  private getter hash : Hash(String, String) = {} of String => String
+  private getter hash = {} of String => String
   forward_missing_to hash
 
   def set_json(key, value)

--- a/src/placeos-driver/storage.cr
+++ b/src/placeos-driver/storage.cr
@@ -42,6 +42,8 @@ abstract class PlaceOS::Driver::Storage
     delete(key) { nil }
   end
 
+  abstract def to_h
+
   abstract def keys
 
   abstract def values

--- a/src/placeos-driver/storage.cr
+++ b/src/placeos-driver/storage.cr
@@ -1,8 +1,16 @@
 abstract class PlaceOS::Driver; end
 
 # Abstraction of a redis hset
-abstract class PlaceOS::Driver::Storage < Hash(String, String)
+abstract class PlaceOS::Driver::Storage
   DEFAULT_PREFIX = "status"
+
+  getter hash_key : String
+  getter id : String
+  getter prefix : String
+
+  def initialize(@id : String, @prefix = DEFAULT_PREFIX)
+    @hash_key = "#{prefix}/#{@id}"
+  end
 
   abstract def signal_status(status_name) : String?
 end

--- a/src/placeos-driver/storage.cr
+++ b/src/placeos-driver/storage.cr
@@ -2,17 +2,62 @@ abstract class PlaceOS::Driver; end
 
 # Abstraction of a redis hset
 abstract class PlaceOS::Driver::Storage
+  include Enumerable({String, String})
+  include Iterable({String, String})
+
   DEFAULT_PREFIX = "status"
 
-  getter hash_key : String
+  getter hash_key : String { "#{prefix}/#{id}" }
   getter id : String
   getter prefix : String
 
   def initialize(@id : String, @prefix = DEFAULT_PREFIX)
-    @hash_key = "#{prefix}/#{@id}"
   end
 
   abstract def signal_status(status_name) : String?
+
+  abstract def []=(status_name, json_value)
+
+  abstract def fetch(key, &block : String ->)
+
+  def fetch(key, default)
+    fetch(key) { default }
+  end
+
+  def [](key, & : String -> String)
+    fetch(key) { yield }
+  end
+
+  def [](key)
+    fetch(key) { raise KeyError.new "Missing hash key: #{key.inspect}" }
+  end
+
+  def []?(key)
+    fetch(key, nil)
+  end
+
+  abstract def delete(key, &block : String ->)
+
+  def delete(key)
+    delete(key) { nil }
+  end
+
+  abstract def keys
+
+  abstract def values
+
+  abstract def size
+
+  abstract def empty?
+
+  abstract def clear
+
+  # To conform to the `Enumerable` interface.
+  def each(&block : {String, String} -> _)
+    each.each do |k, v|
+      yield({k, v})
+    end
+  end
 end
 
 # Fix for a Hash dup issues on crystal 0.36.0

--- a/src/placeos-driver/storage/edge-storage.cr
+++ b/src/placeos-driver/storage/edge-storage.cr
@@ -3,7 +3,7 @@ require "../protocol"
 
 class PlaceOS::Driver::EdgeStorage < PlaceOS::Driver::Storage
   private getter hash : Hash(String, String) = {} of String => String
-  forward_missing_to hash
+  delegate fetch, each, keys, values, size, to: hash
 
   # This is the same as setting a value as this is often used when
   # a hash value is updated and we want to notify of this change.
@@ -31,7 +31,7 @@ class PlaceOS::Driver::EdgeStorage < PlaceOS::Driver::Storage
     json_value
   end
 
-  def delete(key)
+  def delete(key, &block : String ->)
     key = key.to_s
     value = hash.delete(key)
     if value

--- a/src/placeos-driver/storage/edge-storage.cr
+++ b/src/placeos-driver/storage/edge-storage.cr
@@ -2,30 +2,11 @@ require "../storage"
 require "../protocol"
 
 class PlaceOS::Driver::EdgeStorage < PlaceOS::Driver::Storage
-  def initialize(@id : String, @prefix = DEFAULT_PREFIX)
-    super()
-    @hash_key = "#{prefix}/#{@id}"
-  end
-
-  getter hash_key : String
-  getter id : String
-  getter prefix : String
-
-  def []=(status_name, json_value)
-    status_name = status_name.to_s
-    adjusted_value = json_value.to_s.presence
-
-    if adjusted_value
-      upsert(status_name, adjusted_value)
-      PlaceOS::Driver::Protocol.instance.request(hash_key, "hset", "#{status_name}\x03#{adjusted_value}", raw: true)
-    else
-      delete(status_name)
-    end
-    json_value
-  end
+  private getter hash : Hash(String, String) = {} of String => String
+  forward_missing_to hash
 
   # This is the same as setting a value as this is often used when
-  # a hash value is updated and we want to notify of this change
+  # a hash value is updated and we want to notify of this change.
   def signal_status(status_name) : String?
     status_name = status_name.to_s
     json_value = self[status_name]?
@@ -34,9 +15,25 @@ class PlaceOS::Driver::EdgeStorage < PlaceOS::Driver::Storage
     json_value
   end
 
+  # Hash methods
+  #################################################################################################
+
+  def []=(status_name, json_value)
+    status_name = status_name.to_s
+    adjusted_value = json_value.to_s.presence
+
+    if adjusted_value
+      hash[status_name] = adjusted_value
+      PlaceOS::Driver::Protocol.instance.request(hash_key, "hset", "#{status_name}\x03#{adjusted_value}", raw: true)
+    else
+      delete(status_name)
+    end
+    json_value
+  end
+
   def delete(key)
     key = key.to_s
-    value = delete_impl(key)
+    value = hash.delete(key)
     if value
       PlaceOS::Driver::Protocol.instance.request(hash_key, "hset", "#{key}\x03null", raw: true)
       return value
@@ -45,7 +42,7 @@ class PlaceOS::Driver::EdgeStorage < PlaceOS::Driver::Storage
   end
 
   def clear
-    clear_impl
+    hash.clear
     PlaceOS::Driver::Protocol.instance.request(hash_key, "clear", raw: true)
     self
   end

--- a/src/placeos-driver/storage/edge-storage.cr
+++ b/src/placeos-driver/storage/edge-storage.cr
@@ -3,7 +3,7 @@ require "../protocol"
 
 class PlaceOS::Driver::EdgeStorage < PlaceOS::Driver::Storage
   private getter hash : Hash(String, String) = {} of String => String
-  delegate fetch, each, keys, values, size, to: hash
+  delegate fetch, each, keys, values, size, to_h, to: hash
 
   # This is the same as setting a value as this is often used when
   # a hash value is updated and we want to notify of this change.

--- a/src/placeos-driver/storage/redis-storage.cr
+++ b/src/placeos-driver/storage/redis-storage.cr
@@ -26,7 +26,7 @@ class PlaceOS::Driver::RedisStorage < PlaceOS::Driver::Storage
   end
 
   def to_h
-    each.each.each_with_object({} of String => String) do |(key, value), hash|
+    each.each_with_object({} of String => String) do |(key, value), hash|
       hash[key] = value
     end
   end

--- a/src/placeos-driver/storage/redis-storage.cr
+++ b/src/placeos-driver/storage/redis-storage.cr
@@ -19,8 +19,6 @@ class PlaceOS::Driver::RedisStorage < PlaceOS::Driver::Storage
   # Hash methods
   #################################################################################################
 
-  forward_missing_to to_h
-
   def each
     @@redis_lock.synchronize { redis.hgetall(hash_key) }
       .each_slice(2, reuse: true)

--- a/src/placeos-driver/utilities/discovery.cr
+++ b/src/placeos-driver/utilities/discovery.cr
@@ -105,7 +105,7 @@ abstract class PlaceOS::Driver
       {% if compiler_enforced %}
         {% methods = methods.reject { |method| RESERVED_METHODS[method.name.stringify] } %}
         {% methods = methods.reject { |method| method.visibility != :public } %}
-        {% methods = methods.reject { |method| method.accepts_block? } %}
+        {% methods = methods.reject &.accepts_block? %}
       {% else %}
         {% methods = [] of Crystal::Macros::TypeNode %}
       {% end %}


### PR DESCRIPTION
Extending stdlib interfaces is generally frowned upon by the crystal community. 
In this case, this PR is a step towards unblocking sentry integration. 

Includes a small optimisation to `RedisStorage#to_h`

See PlaceOS/rest-api/pull/89 and the referenced Raven.cr issue