### PR TITLE
fix(interface/electrical_relay): add missing type to #pulse

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 5.1.0
+version: 5.1.1
 crystal: ">= 0.36.1"
 
 dependencies:

--- a/src/placeos-driver/interface/electrical_relay.cr
+++ b/src/placeos-driver/interface/electrical_relay.cr
@@ -4,7 +4,7 @@ module PlaceOS::Driver::Interface::ElectricalRelay
   # `**options` here should be passed to the `task` to allow for different priorities
   abstract def relay(state : Bool, index : Int32 = 0, **options)
 
-  def pulse(period : Int32 = 1000, index : Int32 = 0, times : Int32 = 1, initial_state = false)
+  def pulse(period : Int32 = 1000, index : Int32 = 0, times : Int32 = 1, initial_state : Bool = false)
     queue(name: "pulse_#{index}") do |task|
       # higher pririty so these commands run next once added to the queue
       priority = queue.priority + 25


### PR DESCRIPTION
Adds a missing type `intial_state` argument of `PlaceOS::Driver::Interface::ElectricalRelay#pulse`