### PR TITLE
feat(metadata): use json schema for function arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
-on: push
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
 jobs:
   style:
       runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ on: push
 jobs:
   style:
       runs-on: ubuntu-latest
+      container:
+        image: crystallang/crystal
       steps:
-        - name: Install Crystal
-          uses: oprypin/install-crystal@v1
         - name: Check out repository code
           uses: actions/checkout@v2
         - name: Format
@@ -19,32 +19,35 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest]
-          crystal: [latest, nightly]
+          crystal:
+            - latest
+            - nightly
+            - 1.0.0
+            - 0.36.1
       runs-on: ${{ matrix.os }}
+      container: crystallang/crystal:${{ matrix.crystal }}-alpine
+
+      # Service containers to run with `container-job`
+      services:
+        # Label used to access the service container
+        redis:
+          # Docker Hub image
+          image: redis
+          # Set health checks to wait until redis has started
+          options: >-
+            --health-cmd "redis-cli ping"
+            --health-interval 10s
+            --health-timeout 5s
+            --health-retries 5
+
       steps:
-        - name: Install Crystal
-          uses: oprypin/install-crystal@v1
-          with:
-            crystal: ${{ matrix.crystal }}
-        - name: Install the latest version of LibSSH2
-          run: |
-            wget https://launchpad.net/ubuntu/+source/libgcrypt20/1.8.3-1ubuntu1/+build/15106861/+files/libgcrypt20-dev_1.8.3-1ubuntu1_amd64.deb
-            wget https://launchpad.net/ubuntu/+source/libgcrypt20/1.8.3-1ubuntu1/+build/15106861/+files/libgcrypt20_1.8.3-1ubuntu1_amd64.deb
-            wget https://launchpad.net/ubuntu/+source/libgpg-error/1.32-1/+build/15118612/+files/libgpg-error-dev_1.32-1_amd64.deb
-            wget https://launchpad.net/ubuntu/+source/libgpg-error/1.32-1/+build/15118612/+files/libgpg-error0_1.32-1_amd64.deb
-            wget https://launchpad.net/ubuntu/+source/libssh2/1.8.0-2/+build/15151524/+files/libssh2-1-dev_1.8.0-2_amd64.deb
-            wget https://launchpad.net/ubuntu/+source/libssh2/1.8.0-2/+build/15151524/+files/libssh2-1_1.8.0-2_amd64.deb
-            sudo dpkg -i libgpg-error0_1.32-1_amd64.deb
-            sudo dpkg -i libgcrypt20_1.8.3-1ubuntu1_amd64.deb
-            sudo dpkg -i libssh2-1_1.8.0-2_amd64.deb
-            sudo dpkg -i libgpg-error-dev_1.32-1_amd64.deb
-            sudo dpkg -i libgcrypt20-dev_1.8.3-1ubuntu1_amd64.deb
-            sudo dpkg -i libssh2-1-dev_1.8.0-2_amd64.deb
-        - name: Install Redis
-          run: docker run -d -p 6379:6379 redis:6-alpine
+        - name: Install LibSSH2
+          run: apk add --no-cache libssh2 libssh2-dev libssh2-static iputils
         - name: Check out repository code
           uses: actions/checkout@v2
         - name: Install dependencies
           run: shards install --ignore-crystal-version
         - name: Run tests
           run: crystal spec -v --error-trace
+          env:
+            REDIS_URL: redis://redis:6379

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   push:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * 1"

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 5.1.1
+version: 5.2.0
 crystal: ">= 0.36.1"
 
 dependencies:

--- a/spec/driver_proxy_spec.cr
+++ b/spec/driver_proxy_spec.cr
@@ -27,9 +27,9 @@ describe PlaceOS::Driver::Proxy::Driver do
 
     PlaceOS::Driver::RedisStorage.with_redis do |redis|
       meta = PlaceOS::Driver::DriverModel::Metadata.new({
-        "function1" => {} of String => Array(JSON::Any),
-        "function2" => {"arg1" => [JSON::Any.new "Int32"]},
-        "function3" => {"arg1" => [JSON::Any.new "Int32"], "arg2" => [JSON::Any.new("Int32"), JSON::Any.new(200_i64)]},
+        "function1" => {} of String => JSON::Any,
+        "function2" => {"arg1" => JSON.parse(%({"type":"integer"}))},
+        "function3" => {"arg1" => JSON.parse(%({"type":"integer"})), "arg2" => JSON.parse(%({"type":"integer","default":200}))},
       }, ["Functoids"])
 
       redis.set("interface/mod-1234", meta.to_json)

--- a/spec/driver_spec.cr
+++ b/spec/driver_spec.cr
@@ -49,20 +49,20 @@ describe PlaceOS::Driver::DriverManager do
 
     {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.functions.should eq(%({
       "switch_input":{
-        "input":["{\\"type\\":\\"string\\",\\"enum\\":[\\"HDMI\\",\\"DisplayPort\\",\\"HDBaseT\\"]}"]
+        "input":[{"type":"string","enum":["HDMI","DisplayPort","HDBaseT"]}]
       },
       "add":{
-        "a":["{\\"type\\":\\"integer\\"}"],
-        "b":["{\\"type\\":\\"integer\\"}"]
+        "a":[{"type":"integer"}],
+        "b":[{"type":"integer"}]
       },
       "splat_add":{},
       "perform_task":{
-        "name":["{\\"anyOf\\":[{\\"type\\":\\"integer\\"},{\\"type\\":\\"string\\"}]}"]
+        "name":[{"anyOf":[{"type":"integer"},{"type":"string"}]}]
       },
       "error_task":{},
       "future_add":{
-        "a":["{\\"type\\":\\"integer\\"}"],
-        "b":["{\\"type\\":\\"integer\\"}", 200]
+        "a":[{"type":"integer"}],
+        "b":[{"type":"integer"}, 200]
       },
       "future_error":{},
       "raise_error":{},

--- a/spec/driver_spec.cr
+++ b/spec/driver_spec.cr
@@ -47,22 +47,48 @@ describe PlaceOS::Driver::DriverManager do
     ))
     executor.execute(driver).should eq(%("DisplayPort"))
 
-    {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.functions.should eq(%({
+    iface, funcs = {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.functions
+    iface.should eq(%({
       "switch_input":{
-        "input":[{"type":"string","enum":["hdmi","display_port","hd_base_t"],"title":"Helper::TestDriver::Input"}]
+        "input":{"type":"string","enum":["hdmi","display_port","hd_base_t"],"title":"Helper::TestDriver::Input"}
       },
       "add":{
-        "a":[{"type":"integer","title":"Int32"}],
-        "b":[{"type":"integer","title":"Int32"}]
+        "a":{"type":"integer","title":"Int32"},
+        "b":{"type":"integer","title":"Int32"}
       },
       "splat_add":{},
       "perform_task":{
-        "name":[{"anyOf":[{"type":"integer"},{"type":"string"}],"title":"(Int32 | String)"}]
+        "name":{"anyOf":[{"type":"integer"},{"type":"string"}],"title":"(Int32 | String)"}
       },
       "error_task":{},
       "future_add":{
-        "a":[{"type":"integer","title":"Int32"}],
-        "b":[{"type":"integer","title":"Int32","default":200}, 200]
+        "a":{"type":"integer","title":"Int32"},
+        "b":{"type":"integer","title":"Int32","default":200}
+      },
+      "future_error":{},
+      "raise_error":{},
+      "not_json":{},
+      "test_http":{},
+      "test_exec":{},
+      "implemented_in_base_class":{}
+    }).gsub(/\s/, "").gsub(/\|/, " | "))
+
+    funcs.should eq(%({
+      "switch_input":{
+          "input":["Input"]
+      },
+      "add":{
+        "a":["Int32"],
+        "b":["Int32"]
+      },
+      "splat_add":{},
+      "perform_task":{
+        "name":["String | Int32"]
+      },
+      "error_task":{},
+      "future_add":{
+        "a":["Int32"],
+        "b":["Int32",200]
       },
       "future_error":{},
       "raise_error":{},

--- a/spec/driver_spec.cr
+++ b/spec/driver_spec.cr
@@ -49,20 +49,20 @@ describe PlaceOS::Driver::DriverManager do
 
     {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.functions.should eq(%({
       "switch_input":{
-        "input":["String"]
+        "input":["{\\"type\\":\\"string\\",\\"enum\\":[\\"HDMI\\",\\"DisplayPort\\",\\"HDBaseT\\"]}"]
       },
       "add":{
-        "a":["Int32"],
-        "b":["Int32"]
+        "a":["{\\"type\\":\\"integer\\"}"],
+        "b":["{\\"type\\":\\"integer\\"}"]
       },
       "splat_add":{},
       "perform_task":{
-        "name":["String | Int32"]
+        "name":["{\\"anyOf\\":[{\\"type\\":\\"integer\\"},{\\"type\\":\\"string\\"}]}"]
       },
       "error_task":{},
       "future_add":{
-        "a":["Int32"],
-        "b":["Int32", 200]
+        "a":["{\\"type\\":\\"integer\\"}"],
+        "b":["{\\"type\\":\\"integer\\"}", 200]
       },
       "future_error":{},
       "raise_error":{},

--- a/spec/driver_spec.cr
+++ b/spec/driver_spec.cr
@@ -49,7 +49,7 @@ describe PlaceOS::Driver::DriverManager do
 
     {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.functions.should eq(%({
       "switch_input":{
-        "input":[{"type":"string","enum":["HDMI","DisplayPort","HDBaseT"],"title":"Helper::TestDriver::Input"}]
+        "input":[{"type":"string","enum":["hdmi","display_port","hd_base_t"],"title":"Helper::TestDriver::Input"}]
       },
       "add":{
         "a":[{"type":"integer","title":"Int32"}],

--- a/spec/driver_spec.cr
+++ b/spec/driver_spec.cr
@@ -49,20 +49,20 @@ describe PlaceOS::Driver::DriverManager do
 
     {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.functions.should eq(%({
       "switch_input":{
-        "input":[{"type":"string","enum":["HDMI","DisplayPort","HDBaseT"]}]
+        "input":[{"type":"string","enum":["HDMI","DisplayPort","HDBaseT"],"title":"Helper::TestDriver::Input"}]
       },
       "add":{
-        "a":[{"type":"integer"}],
-        "b":[{"type":"integer"}]
+        "a":[{"type":"integer","title":"Int32"}],
+        "b":[{"type":"integer","title":"Int32"}]
       },
       "splat_add":{},
       "perform_task":{
-        "name":[{"anyOf":[{"type":"integer"},{"type":"string"}]}]
+        "name":[{"anyOf":[{"type":"integer"},{"type":"string"}],"title":"(Int32 | String)"}]
       },
       "error_task":{},
       "future_add":{
-        "a":[{"type":"integer"}],
-        "b":[{"type":"integer"}, 200]
+        "a":[{"type":"integer","title":"Int32"}],
+        "b":[{"type":"integer","title":"Int32","default":200}, 200]
       },
       "future_error":{},
       "raise_error":{},

--- a/spec/drivers_proxy_spec.cr
+++ b/spec/drivers_proxy_spec.cr
@@ -31,15 +31,15 @@ module PlaceOS::Driver::Proxy
       # Create the driver metadata
       redis = PlaceOS::Driver::RedisStorage.new_redis_client
       meta = PlaceOS::Driver::DriverModel::Metadata.new({
-        "function1" => {} of String => Array(JSON::Any),
-        "function2" => {"arg1" => [JSON::Any.new "Int32"]},
-        "function3" => {"arg1" => [JSON::Any.new "Int32"], "arg2" => [JSON::Any.new("Int32"), JSON::Any.new(200_i64)]},
+        "function1" => {} of String => JSON::Any,
+        "function2" => {"arg1" => JSON.parse(%({"type":"integer"}))},
+        "function3" => {"arg1" => JSON.parse(%({"type":"integer"})), "arg2" => JSON.parse(%({"type":"integer","default":200}))},
       }, ["Functoids"])
       redis.set("interface/mod-999", meta.to_json)
       redis.set("interface/mod-888", meta.to_json)
 
       meta = PlaceOS::Driver::DriverModel::Metadata.new({
-        "function1" => {} of String => Array(JSON::Any),
+        "function1" => {} of String => JSON::Any,
       })
       redis.set("interface/mod-444", meta.to_json)
 

--- a/spec/scheduler_spec.cr
+++ b/spec/scheduler_spec.cr
@@ -62,21 +62,21 @@ describe PlaceOS::Driver::Proxy::Scheduler do
   it "should schedule a repeating task" do
     sched = PlaceOS::Driver::Proxy::Scheduler.new
     ran = 0
-    task = sched.every(4.milliseconds) { ran += 1 }
+    task = sched.every(32.milliseconds) { ran += 1 }
 
-    sleep 2.milliseconds
+    sleep 16.milliseconds
     sched.size.should eq(1)
     ran.should eq(0)
 
-    sleep 3.milliseconds
+    sleep 24.milliseconds
     ran.should eq(1)
     sched.size.should eq(1)
 
-    sleep 4.milliseconds
+    sleep 32.milliseconds
     ran.should eq(2)
     sched.size.should eq(1)
 
-    sleep 4.milliseconds
+    sleep 32.milliseconds
     ran.should eq(3)
     sched.size.should eq(1)
 
@@ -88,23 +88,23 @@ describe PlaceOS::Driver::Proxy::Scheduler do
     sched = PlaceOS::Driver::Proxy::Scheduler.new
     ran = 0
     single = 0
-    sched.in(2.milliseconds) { single += 1 }
-    task = sched.every(4.milliseconds) { ran += 1 }
+    sched.in(16.milliseconds) { single += 1 }
+    task = sched.every(32.milliseconds) { ran += 1 }
 
-    sleep 3.milliseconds
+    sleep 24.milliseconds
     sched.size.should eq(1)
     ran.should eq(0)
     single.should eq(1)
 
-    sleep 2.milliseconds
+    sleep 16.milliseconds
     ran.should eq(1)
     sched.size.should eq(1)
 
-    sleep 4.milliseconds
+    sleep 32.milliseconds
     ran.should eq(2)
     sched.size.should eq(1)
 
-    sleep 4.milliseconds
+    sleep 32.milliseconds
     ran.should eq(3)
     sched.size.should eq(1)
 
@@ -115,27 +115,27 @@ describe PlaceOS::Driver::Proxy::Scheduler do
   it "should pause and resume a repeating task" do
     sched = PlaceOS::Driver::Proxy::Scheduler.new
     ran = 0
-    task = sched.every(2.milliseconds) { ran += 1; ran }
+    task = sched.every(24.milliseconds) { ran += 1; ran }
 
-    sleep 3.milliseconds
+    sleep 36.milliseconds
     ran.should eq(1)
     sched.size.should eq(1)
 
-    sleep 2.milliseconds
+    sleep 24.milliseconds
     ran.should eq(2)
     sched.size.should eq(1)
 
     task.cancel
     sched.size.should eq(0)
 
-    sleep 2.milliseconds
+    sleep 24.milliseconds
     ran.should eq(2)
     sched.size.should eq(0)
 
     task.resume
     sched.size.should eq(1)
 
-    sleep 3.milliseconds
+    sleep 36.milliseconds
     ran.should eq(3)
     sched.size.should eq(1)
 

--- a/spec/scheduler_spec.cr
+++ b/spec/scheduler_spec.cr
@@ -41,21 +41,17 @@ describe PlaceOS::Driver::Proxy::Scheduler do
 
     # Test failure
     task = sched.at(2.milliseconds.from_now) { raise "was error" }
-    begin
+    expect_raises(Exception, "was error") do
       task.get
       raise "not here"
-    rescue error
-      error.message.should eq "was error"
     end
 
-    # Test cancelation
+    # Test cancellation
     task = sched.at(2.milliseconds.from_now) { true }
     spawn(same_thread: true) { task.cancel }
-    begin
+    expect_raises(Exception, "Task cancelled") do
       task.get
       raise "failed"
-    rescue error
-      error.message.should eq "Task canceled"
     end
   end
 
@@ -155,21 +151,16 @@ describe PlaceOS::Driver::Proxy::Scheduler do
     task.get.should eq 1
     task.get.should eq 2
     task.get.should eq 3
-    begin
+    expect_raises(Exception, "some error") do
       task.get.should eq 4
       raise "failed"
-    rescue error
-      error.message.should eq "some error"
     end
     task.get.should eq 5
 
     # Test cancelation
     spawn(same_thread: true) { task.cancel }
-    begin
+    expect_raises(Exception, "Task cancelled") do
       task.get
-      raise "failed"
-    rescue error
-      error.message.should eq "Task canceled"
     end
   end
 end

--- a/spec/scheduler_spec.cr
+++ b/spec/scheduler_spec.cr
@@ -35,9 +35,13 @@ describe PlaceOS::Driver::Proxy::Scheduler do
   it "should be possible to obtain the return value of the task" do
     sched = PlaceOS::Driver::Proxy::Scheduler.new
 
+    puts "checking get"
+
     # Test execution
     task = sched.at(2.milliseconds.from_now) { true }
     task.get.should eq true
+
+    puts "checking raise"
 
     # Test failure
     task = sched.at(2.milliseconds.from_now) { raise "was error" }
@@ -48,6 +52,8 @@ describe PlaceOS::Driver::Proxy::Scheduler do
       error.message.should eq "was error"
     end
 
+    puts "checking cancel"
+
     # Test cancelation
     task = sched.at(2.milliseconds.from_now) { true }
     spawn(same_thread: true) { task.cancel }
@@ -57,28 +63,42 @@ describe PlaceOS::Driver::Proxy::Scheduler do
     rescue error
       error.message.should eq "Task canceled"
     end
+
+    puts "completed"
   end
 
   it "should schedule a repeating task" do
+    puts "checking schedule"
+
     sched = PlaceOS::Driver::Proxy::Scheduler.new
     ran = 0
     task = sched.every(4.milliseconds) { ran += 1 }
+
+    puts "did it run?"
 
     sleep 2.milliseconds
     sched.size.should eq(1)
     ran.should eq(0)
 
+    puts "did it run? 2"
+
     sleep 3.milliseconds
     ran.should eq(1)
     sched.size.should eq(1)
+
+    puts "did it run? 3"
 
     sleep 4.milliseconds
     ran.should eq(2)
     sched.size.should eq(1)
 
+    puts "did it run? 4"
+
     sleep 4.milliseconds
     ran.should eq(3)
     sched.size.should eq(1)
+
+    puts "did it run? 5"
 
     task.cancel
     sched.size.should eq(0)

--- a/spec/scheduler_spec.cr
+++ b/spec/scheduler_spec.cr
@@ -35,13 +35,9 @@ describe PlaceOS::Driver::Proxy::Scheduler do
   it "should be possible to obtain the return value of the task" do
     sched = PlaceOS::Driver::Proxy::Scheduler.new
 
-    puts "checking get"
-
     # Test execution
     task = sched.at(2.milliseconds.from_now) { true }
     task.get.should eq true
-
-    puts "checking raise"
 
     # Test failure
     task = sched.at(2.milliseconds.from_now) { raise "was error" }
@@ -52,8 +48,6 @@ describe PlaceOS::Driver::Proxy::Scheduler do
       error.message.should eq "was error"
     end
 
-    puts "checking cancel"
-
     # Test cancelation
     task = sched.at(2.milliseconds.from_now) { true }
     spawn(same_thread: true) { task.cancel }
@@ -63,42 +57,28 @@ describe PlaceOS::Driver::Proxy::Scheduler do
     rescue error
       error.message.should eq "Task canceled"
     end
-
-    puts "completed"
   end
 
   it "should schedule a repeating task" do
-    puts "checking schedule"
-
     sched = PlaceOS::Driver::Proxy::Scheduler.new
     ran = 0
     task = sched.every(4.milliseconds) { ran += 1 }
-
-    puts "did it run?"
 
     sleep 2.milliseconds
     sched.size.should eq(1)
     ran.should eq(0)
 
-    puts "did it run? 2"
-
     sleep 3.milliseconds
     ran.should eq(1)
     sched.size.should eq(1)
-
-    puts "did it run? 3"
 
     sleep 4.milliseconds
     ran.should eq(2)
     sched.size.should eq(1)
 
-    puts "did it run? 4"
-
     sleep 4.milliseconds
     ran.should eq(3)
     sched.size.should eq(1)
-
-    puts "did it run? 5"
 
     task.cancel
     sched.size.should eq(0)

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -14,8 +14,12 @@ class SchemaKlass
   property cmd : String
   property other : Int32?
 
-  @[JSON::Field(converter: Enum::ValueConverter(TestEnum))]
-  property foo : TestEnum
+  {% if compare_versions(Crystal::VERSION, "1.0.0") >= 0 %}
+    @[JSON::Field(converter: Enum::ValueConverter(TestEnum))]
+    property foo : TestEnum
+  {% else %}
+    property foo : TestEnum
+  {% end %}
 end
 
 class SchemaKlassNoRequired
@@ -115,7 +119,10 @@ describe PlaceOS::Driver::Settings do
     PlaceOS::Driver::Settings.introspect(Hash(String, Int32)).should eq({type: "object", additionalProperties: {type: "integer"}})
     PlaceOS::Driver::Settings.introspect(SuperHash).should eq({type: "object"})
     PlaceOS::Driver::Settings.introspect(Bool | String).should eq({anyOf: [{type: "boolean"}, {type: "string"}]})
-    PlaceOS::Driver::Settings.introspect(SchemaKlass).should eq({type: "object", properties: {cmd: {type: "string"}, other: {anyOf: [{type: "integer"}, {type: "null"}]}, foo: {enum: [0, 1]}}, required: ["cmd", "foo"]})
+
+    {% unless compare_versions(Crystal::VERSION, "1.0.0") < 0 %}
+      PlaceOS::Driver::Settings.introspect(SchemaKlass).should eq({type: "object", properties: {cmd: {type: "string"}, other: {anyOf: [{type: "integer"}, {type: "null"}]}, foo: {enum: [0, 1]}}, required: ["cmd", "foo"]})
+    {% end %}
 
     # test where no fields are required
     PlaceOS::Driver::Settings.introspect(NamedTuple(steve: String?)).should eq({type: "object", properties: {steve: {anyOf: [{type: "null"}, {type: "string"}]}}})

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -13,6 +13,9 @@ class SchemaKlass
   include JSON::Serializable
   property cmd : String
   property other : Int32?
+
+  @[JSON::Field(converter: Enum::ValueConverter(TestEnum))]
+  property foo : TestEnum
 end
 
 class SchemaKlassNoRequired
@@ -103,7 +106,7 @@ describe PlaceOS::Driver::Settings do
     PlaceOS::Driver::Settings.introspect(Array(Bool)).should eq({type: "array", items: {type: "boolean"}})
     PlaceOS::Driver::Settings.introspect(Array(JSON::Any)).should eq({type: "array"})
     PlaceOS::Driver::Settings.introspect(NamedTuple(steve: String)).should eq({type: "object", properties: {steve: {type: "string"}}, required: ["steve"]})
-    PlaceOS::Driver::Settings.introspect(TestEnum).should eq({type: "string", enum: ["Bob", "Jane"]})
+    PlaceOS::Driver::Settings.introspect(TestEnum).should eq({type: "string", enum: ["bob", "jane"]})
     PlaceOS::Driver::Settings.introspect(Tuple(String, Bool)).should eq({type: "array", items: [{type: "string"}, {type: "boolean"}]})
     PlaceOS::Driver::Settings.introspect(SomeType).should eq({anyOf: [
       {type: "string"},
@@ -112,7 +115,7 @@ describe PlaceOS::Driver::Settings do
     PlaceOS::Driver::Settings.introspect(Hash(String, Int32)).should eq({type: "object", additionalProperties: {type: "integer"}})
     PlaceOS::Driver::Settings.introspect(SuperHash).should eq({type: "object"})
     PlaceOS::Driver::Settings.introspect(Bool | String).should eq({anyOf: [{type: "boolean"}, {type: "string"}]})
-    PlaceOS::Driver::Settings.introspect(SchemaKlass).should eq({type: "object", properties: {cmd: {type: "string"}, other: {anyOf: [{type: "integer"}, {type: "null"}]}}, required: ["cmd"]})
+    PlaceOS::Driver::Settings.introspect(SchemaKlass).should eq({type: "object", properties: {cmd: {type: "string"}, other: {anyOf: [{type: "integer"}, {type: "null"}]}, foo: {enum: [0, 1]}}, required: ["cmd", "foo"]})
 
     # test where no fields are required
     PlaceOS::Driver::Settings.introspect(NamedTuple(steve: String?)).should eq({type: "object", properties: {steve: {anyOf: [{type: "null"}, {type: "string"}]}}})

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -413,7 +413,6 @@ abstract class PlaceOS::Driver
         iface, funcs = self.functions
 
         %({
-          "functions": #{self.functions},
           "interface": #{iface},
           "functions": #{funcs},
           "implements": #{implements.to_json},

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -359,12 +359,12 @@ abstract class PlaceOS::Driver
 
             {{method.name.stringify}} => {
               {% for arg in args %}
-                {{arg.name.stringify}} => [
-                  PlaceOS::Driver::Settings.introspect({{arg.restriction.resolve}}).to_json,
+                {{arg.name.stringify}} => {
+                  PlaceOS::Driver::Settings.introspect({{arg.restriction.resolve}}),
                   {% if !arg.default_value.is_a?(Nop) %}
                     {{arg.default_value}}
                   {% end %}
-                ],
+                },
               {% end %}
             }{% if args.size == 0 %} of String => Array(String) {% end %},
           {% end %}

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -359,14 +359,14 @@ abstract class PlaceOS::Driver
 
             {{method.name.stringify}} => {
               {% for arg in args %}
-                {{arg.name.stringify}} => {
+                {{arg.name.stringify}} => [
                   PlaceOS::Driver::Settings.introspect({{arg.restriction.resolve}}).to_json,
                   {% if !arg.default_value.is_a?(Nop) %}
                     {{arg.default_value}}
                   {% end %}
-                },
+                ],
               {% end %}
-            }{% if args.size == 0 %} of String => Array(String){% end %},
+            }{% if args.size == 0 %} of String => Array(String) {% end %},
           {% end %}
         }.to_json
         funcs

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -359,19 +359,12 @@ abstract class PlaceOS::Driver
 
             {{method.name.stringify}} => {
               {% for arg in args %}
-                {{arg.name.stringify}} => [
-                  {% if !arg.restriction.is_a?(Union) && arg.restriction.resolve < ::Enum %}
-                    "String",
-                    {% if !arg.default_value.is_a?(Nop) %}
-                      {{arg.default_value}}.to_s
-                    {% end %}
-                  {% else %}
-                    {{arg.restriction.stringify}},
-                    {% if !arg.default_value.is_a?(Nop) %}
-                      {{arg.default_value}}
-                    {% end %}
+                {{arg.name.stringify}} => {
+                  PlaceOS::Driver::Settings.introspect({{arg.restriction.resolve}}).to_json,
+                  {% if !arg.default_value.is_a?(Nop) %}
+                    {{arg.default_value}}
                   {% end %}
-                ],
+                },
               {% end %}
             }{% if args.size == 0 %} of String => Array(String){% end %},
           {% end %}

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -360,9 +360,12 @@ abstract class PlaceOS::Driver
             {{method.name.stringify}} => {
               {% for arg in args %}
                 {{arg.name.stringify}} => {
-                  PlaceOS::Driver::Settings.introspect({{arg.restriction.resolve}}),
-                  {% if !arg.default_value.is_a?(Nop) %}
-                    {{arg.default_value}}
+                  PlaceOS::Driver::Settings.introspect({{arg.restriction.resolve}}).
+                  {% if arg.default_value.is_a?(Nop) %}
+                    merge({ title: {{arg.restriction.resolve.stringify}} }),
+                  {% else %}
+                    merge({ title: {{arg.restriction.resolve.stringify}}, default: {{arg.default_value}} }),
+                    {{arg.default_value}},
                   {% end %}
                 },
               {% end %}

--- a/src/placeos-driver/proxy/driver.cr
+++ b/src/placeos-driver/proxy/driver.cr
@@ -39,7 +39,7 @@ class PlaceOS::Driver::Proxy::Driver
   end
 
   def implements?(interface) : Bool
-    @metadata.implements.includes?(interface.to_s) || !!@metadata.functions[interface.to_s]?
+    @metadata.implements.includes?(interface.to_s) || !!@metadata.interface[interface.to_s]?
   end
 
   # All subscriptions to external drivers should be indirect as the driver might
@@ -53,7 +53,7 @@ class PlaceOS::Driver::Proxy::Driver
   # Ensure they are logged and raise if the response is requested
   macro method_missing(call)
     function_name = {{call.name.id.stringify}}
-    function = @metadata.functions[function_name]?
+    function = @metadata.interface[function_name]?
 
     # obtain the arguments provided
     arguments = {{call.args}} {% if call.args.size == 0 %} of String {% end %}
@@ -84,7 +84,7 @@ class PlaceOS::Driver::Proxy::Driver
 
         # check for defaults if there are not enough arguments
         function.each_value do |arg_details|
-          defaults += 1 if arg_details.size > 1
+          defaults += 1 if arg_details["default"]?
         end
 
         minargs = funcsize - defaults
@@ -141,9 +141,9 @@ class PlaceOS::Driver::Proxy::Driver
                     index += 1
                     arguments[index - 1]
                   elsif details.size > 1
-                    details[1]
+                    details["default"]
                   else
-                    raise "missing argument `#{arg_name} : #{details[0]}` for '#{function_name}' on #{module_metadata[:name]}_#{module_metadata[:index]} - #{module_metadata[:id]}"
+                    raise "missing argument `#{arg_name} : #{details["title"]}` for '#{function_name}' on #{module_metadata[:name]}_#{module_metadata[:index]} - #{module_metadata[:id]}"
                   end
                 end
 

--- a/src/placeos-driver/proxy/scheduler.cr
+++ b/src/placeos-driver/proxy/scheduler.cr
@@ -73,18 +73,14 @@ class PlaceOS::Driver::Proxy::Scheduler
     raise "schedule proxy terminated" if @terminated
     spawn(same_thread: true) { run_now(block) } if immediate
     task = Tasker.every(time) { run_now(block) }
-    wrap = TaskWrapper.new(task, @callback)
-    @schedules << wrap
-    wrap
+    TaskWrapper.new(task, @callback).tap { |wrapper| @schedules << wrapper }
   end
 
   def cron(string, timezone : Time::Location = Time::Location.local, immediate = false, &block : -> _)
     raise "schedule proxy terminated" if @terminated
     spawn(same_thread: true) { run_now(block) } if immediate
     task = Tasker.cron(string, timezone) { run_now(block) }
-    wrap = TaskWrapper.new(task, @callback)
-    @schedules << wrap
-    wrap
+    TaskWrapper.new(task, @callback).tap { |wrapper| @schedules << wrapper }
   end
 
   def terminate

--- a/src/placeos-driver/proxy/scheduler.cr
+++ b/src/placeos-driver/proxy/scheduler.cr
@@ -48,7 +48,7 @@ class PlaceOS::Driver::Proxy::Scheduler
     spawn(same_thread: true) { run_now(block) } if immediate
     wrapped = nil
     task = Tasker.at(time) do
-      @schedules.delete(wrapped.not_nil!)
+      @schedules.delete(wrapped)
       run_now(block)
     end
     wrap = wrapped = TaskWrapper.new(task, @callback)
@@ -61,7 +61,7 @@ class PlaceOS::Driver::Proxy::Scheduler
     spawn(same_thread: true) { run_now(block) } if immediate
     wrapped = nil
     task = Tasker.in(time) do
-      @schedules.delete(wrapped.not_nil!)
+      @schedules.delete(wrapped)
       run_now(block)
     end
     wrap = wrapped = TaskWrapper.new(task, @callback)

--- a/src/placeos-driver/proxy/scheduler.cr
+++ b/src/placeos-driver/proxy/scheduler.cr
@@ -17,7 +17,7 @@ class PlaceOS::Driver::Proxy::Scheduler
 
     delegate created, get, last_scheduled, next_epoch, next_scheduled, trigger, trigger_count, to: @task
 
-    def cancel(reason = "Task canceled", terminate = false)
+    def cancel(reason = "Task cancelled", terminate = false)
       @callback.call(self, Action::Remove) unless terminate
       @task.cancel reason
     end

--- a/src/placeos-driver/proxy/system.cr
+++ b/src/placeos-driver/proxy/system.cr
@@ -132,7 +132,7 @@ class PlaceOS::Driver::Proxy::System
       metadata = RedisStorage.get("interface/#{module_id}")
       if module_id && metadata
         data = DriverModel::Metadata.from_json metadata
-        next unless data.implements.includes?(interface) || data.functions[interface]?
+        next unless data.implements.includes?(interface) || data.interface[interface]?
         drivers << Proxy::Driver.new(@reply_id, mod_name, index.to_i, module_id, self, data)
       end
     end


### PR DESCRIPTION
previously it exposed the type name, purely for metadata, but this is much more useful and could be used in backoffice when executing functions to ensure you're entering valid values

no breaking changes by json encoding the schema as a string

This means when you have an argument that is a JSON serialisable object like

```crystal
class Testing
  include JSON::Serializable
  property email : String
  property mobile : String?
end
```

then you get something meaningful in the metadata instead of just `Testing`