### PR TITLE
fix(queue): replace priority queue

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 5.2.0
+version: 5.2.1
 crystal: ">= 0.36.1"
 
 dependencies:

--- a/shard.yml
+++ b/shard.yml
@@ -19,9 +19,6 @@ dependencies:
   ipaddress:
     github: Sija/ipaddress.cr
 
-  priority-queue:
-    github: spider-gazelle/priority-queue
-
   promise:
     github: spider-gazelle/promise
 

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -228,7 +228,7 @@ abstract class PlaceOS::Driver
     # {{klasses.map &.stringify}} <- in case we need to filter out more classes
     {% klasses.map { |a| methods = methods + a.methods } %}
     {% methods = methods.reject { |method| RESERVED_METHODS[method.name.stringify] } %}
-    {% methods = methods.reject { |method| method.visibility != :public } %}
+    {% methods = methods.reject(&.visibility.!=(:public)) %}
     {% methods = methods.reject &.accepts_block? %}
     # Filter out abstract methods
     {% methods = methods.reject &.body.stringify.empty? %}

--- a/src/placeos-driver/driver-specs/mock_driver.cr
+++ b/src/placeos-driver/driver-specs/mock_driver.cr
@@ -111,7 +111,7 @@ abstract class DriverSpecs::MockDriver
     # {{klasses.map &.stringify}} <- in case we need to filter out more classes
     {% klasses.map { |a| methods = methods + a.methods } %}
     {% methods = methods.reject { |method| RESERVED_METHODS[method.name.stringify] } %}
-    {% methods = methods.reject { |method| method.visibility != :public } %}
+    {% methods = methods.reject(&.visibility.!=(:public)) %}
     {% methods = methods.reject &.accepts_block? %}
     # Filter out abstract methods
     {% methods = methods.reject &.body.stringify.empty? %}

--- a/src/placeos-driver/proxy/system.cr
+++ b/src/placeos-driver/proxy/system.cr
@@ -181,7 +181,7 @@ class PlaceOS::Driver::Proxy::System
   # Grabs the number of a particular device type
   def count(module_name)
     module_name = module_name.to_s
-    module_keys.count { |key| key == module_name }
+    module_keys.count(&.==(module_name))
   end
 
   def id

--- a/src/placeos-driver/queue.cr
+++ b/src/placeos-driver/queue.cr
@@ -44,11 +44,12 @@ class PlaceOS::Driver::Queue
 
   # removes all jobs currently in the queue
   def clear(abort_current = false)
-    old_queue = @queue # assignment here to avoid nilable object
-    @mutex.synchronize do
-      # ensure we have the latest version of the queue
-      old_queue = @queue
+    old_queue = @mutex.synchronize do
+      # Ensure we have a reference to the latest version of the queue
+      old = @queue
+      # Create a new queue so tasks can be added as old tasks are cleared
       @queue = Array(Task).new
+      old
     end
 
     # Abort any currently running tasks

--- a/src/placeos-driver/queue.cr
+++ b/src/placeos-driver/queue.cr
@@ -142,9 +142,8 @@ class PlaceOS::Driver::Queue
       end
     elsif name
       @queue.unshift task
-      @queue = @queue
-        .sort! { |a, b| a.apparent_priority <=> b.apparent_priority }
-        .reject { |t| t != task && t.name == name }
+      @queue = @queue.sort { |a, b| a.apparent_priority <=> b.apparent_priority }
+      @queue = @queue.reject { |t| t != task && t.name == name }
     else
       spawn(same_thread: true) { task.abort("transport is currently offline") }
     end

--- a/src/placeos-driver/queue.cr
+++ b/src/placeos-driver/queue.cr
@@ -133,7 +133,7 @@ class PlaceOS::Driver::Queue
     if @online
       @queue.unshift task
       @queue = @queue.sort { |a, b| a.apparent_priority <=> b.apparent_priority }
-      @queue = @queue.reject { |t| t != task && t.name == name } if task.name
+      @queue = @queue.reject { |t| t != task && t.name == name } if name
 
       # buffered channel so this shouldn't block receive
       if @waiting

--- a/src/placeos-driver/queue.cr
+++ b/src/placeos-driver/queue.cr
@@ -103,9 +103,7 @@ class PlaceOS::Driver::Queue
       end
 
       # Check if the previous task should effect the current task
-      if previous = @previous
-        previous.delay_required?
-      end
+      previous.try &.delay_required?
 
       # Perform tasks
       task = @mutex.synchronize { @queue.pop }

--- a/src/placeos-driver/queue.cr
+++ b/src/placeos-driver/queue.cr
@@ -53,7 +53,7 @@ class PlaceOS::Driver::Queue
     end
 
     # Abort all the queued tasks
-    old_queue.each { |task| task.abort("queue cleared") }
+    old_queue.each(&.abort("queue cleared"))
 
     self
   end

--- a/src/placeos-driver/queue.cr
+++ b/src/placeos-driver/queue.cr
@@ -52,7 +52,7 @@ class PlaceOS::Driver::Queue
     end
 
     # Abort any currently running tasks
-    current.abort("queue cleared") if abort_current && (current = @current)
+    @current.try &.abort("queue cleared") if abort_current
 
     # Abort all the queued tasks
     old_queue.each(&.abort("queue cleared"))

--- a/src/placeos-driver/task.cr
+++ b/src/placeos-driver/task.cr
@@ -1,4 +1,3 @@
-require "priority-queue"
 require "tasker"
 require "json"
 

--- a/src/placeos-driver/task.cr
+++ b/src/placeos-driver/task.cr
@@ -35,6 +35,7 @@ class PlaceOS::Driver::Task
   getter last_executed, state, payload, backtrace, error_class
   getter name, delay, wait
   property processing, retries, priority, clear_queue
+  property apparent_priority : Int32 = 0
 
   # Use the Queue's custom logger
   delegate logger, to: @queue

--- a/src/placeos-driver/utilities/discovery.cr
+++ b/src/placeos-driver/utilities/discovery.cr
@@ -104,7 +104,7 @@ abstract class PlaceOS::Driver
 
       {% if compiler_enforced %}
         {% methods = methods.reject { |method| RESERVED_METHODS[method.name.stringify] } %}
-        {% methods = methods.reject { |method| method.visibility != :public } %}
+        {% methods = methods.reject(&.visibility.!=(:public)) %}
         {% methods = methods.reject &.accepts_block? %}
       {% else %}
         {% methods = [] of Crystal::Macros::TypeNode %}


### PR DESCRIPTION
replaces the array over an in-place update

```crystal
# this memory leaks:
@queue.sort! { |a, b| a.apparent_priority <=> b.apparent_priority }
@queue.reject! { |t| t != task && t.name == name }
```

and

```crystal
# this does not
@queue = @queue.sort { |a, b| a.apparent_priority <=> b.apparent_priority }
@queue = @queue.reject { |t| t != task && t.name == name }
```