### PR TITLE
fix(proxy/scheduler): make `TaskWrapper` public

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 5.3.13
+version: 5.3.14
 crystal: ">= 0.36.1"
 
 dependencies:

--- a/src/placeos-driver/proxy/scheduler.cr
+++ b/src/placeos-driver/proxy/scheduler.cr
@@ -4,7 +4,7 @@ require "set"
 require "../driver_manager"
 
 class PlaceOS::Driver::Proxy::Scheduler
-  private class TaskWrapper
+  class TaskWrapper
     enum Action
       Add
       Remove


### PR DESCRIPTION
A handful of drivers reference this private class, causing them to fail to compile. This PR makes the class public, fixing the compilation errors.