### PR TITLE
feat(proxy drivers): ignore failures occuring on batch results

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: v5.4.6
+version: v5.4.7
 crystal: ">= 0.36.1"
 
 dependencies:

--- a/src/placeos-driver/proxy/drivers.cr
+++ b/src/placeos-driver/proxy/drivers.cr
@@ -57,10 +57,17 @@ class PlaceOS::Driver::Proxy::Drivers
 
     @computed : Array(JSON::Any)?
 
-    def get : Array(JSON::Any)
+    def get(raise_on_error : Bool = false) : Array(JSON::Any)
       computed = @computed
       return computed if computed
-      @computed = computed = @results.map &.get
+      @computed = computed = @results.compact_map do |result|
+        begin
+          result.get
+        rescue error
+          raise error if raise_on_error
+          nil
+        end
+      end
       computed
     end
   end


### PR DESCRIPTION
the failures are logged but one failed request of many shouldn't prevent the results being collected.

The main reason for this to occur is when a driver has been stopped and hence the request never makes it.

old behaviour is now optional