### PR TITLE
feat: add invoked_by_user_id as a security context in requests

### DIFF
--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -114,6 +114,10 @@ abstract class PlaceOS::Driver
     @__module_id__
   end
 
+  def invoked_by_user_id
+    Fiber.current.name
+  end
+
   # Status helpers #}
   def []=(key, value)
     key = key.to_s

--- a/src/placeos-driver/driver_manager.cr
+++ b/src/placeos-driver/driver_manager.cr
@@ -136,14 +136,11 @@ class PlaceOS::Driver::DriverManager
 
       promise, request = req_data
       spawn(same_thread: true, name: request.user_id) do
+        Log.context.set user_id: (request.user_id || "internal"), request_id: request.id
         process request
         promise.resolve(nil)
       end
     end
-  end
-
-  protected def current_user_id
-    Fiber.current.name || "internal"
   end
 
   private def process(request)
@@ -176,7 +173,7 @@ class PlaceOS::Driver::DriverManager
           request.payload = result
         end
       rescue error
-        logger.error(exception: error) { "executing #{exec_request} on #{DriverManager.driver_class} (#{request.id}) [#{current_user_id}]" }
+        logger.error(exception: error) { "executing #{exec_request} on #{DriverManager.driver_class} (#{request.id})" }
         request.set_error(error)
       end
     when "update"
@@ -187,7 +184,7 @@ class PlaceOS::Driver::DriverManager
       raise "unexpected request"
     end
   rescue error
-    logger.fatal(exception: error) { "issue processing requests on #{DriverManager.driver_class} (#{request.id}) [#{current_user_id}]" }
+    logger.fatal(exception: error) { "issue processing requests on #{DriverManager.driver_class} (#{request.id})" }
     request.set_error(error)
   end
 

--- a/src/placeos-driver/driver_manager.cr
+++ b/src/placeos-driver/driver_manager.cr
@@ -135,11 +135,15 @@ class PlaceOS::Driver::DriverManager
       break unless req_data
 
       promise, request = req_data
-      spawn(same_thread: true) do
+      spawn(same_thread: true, name: request.user_id) do
         process request
         promise.resolve(nil)
       end
     end
+  end
+
+  protected def current_user_id
+    Fiber.current.name || "internal"
   end
 
   private def process(request)
@@ -172,7 +176,7 @@ class PlaceOS::Driver::DriverManager
           request.payload = result
         end
       rescue error
-        logger.error(exception: error) { "executing #{exec_request} on #{DriverManager.driver_class} (#{request.id})" }
+        logger.error(exception: error) { "executing #{exec_request} on #{DriverManager.driver_class} (#{request.id}) [#{current_user_id}]" }
         request.set_error(error)
       end
     when "update"
@@ -183,7 +187,7 @@ class PlaceOS::Driver::DriverManager
       raise "unexpected request"
     end
   rescue error
-    logger.fatal(exception: error) { "issue processing requests on #{DriverManager.driver_class} (#{request.id})" }
+    logger.fatal(exception: error) { "issue processing requests on #{DriverManager.driver_class} (#{request.id}) [#{current_user_id}]" }
     request.set_error(error)
   end
 

--- a/src/placeos-driver/protocol.cr
+++ b/src/placeos-driver/protocol.cr
@@ -162,8 +162,8 @@ class PlaceOS::Driver::Protocol
     @producer.send({message, nil})
   end
 
-  def request(id, command, payload = nil, raw = false)
-    req = Request.new(id.to_s, command.to_s)
+  def request(id, command, payload = nil, raw = false, user_id = nil)
+    req = Request.new(id.to_s, command.to_s, user_id: user_id)
     if payload
       req.payload = raw ? payload.to_s : payload.to_json
     end
@@ -178,8 +178,8 @@ class PlaceOS::Driver::Protocol
     req
   end
 
-  def expect_response(id, reply_id, command, payload = nil, raw = false) : Channel(Request)
-    req = Request.new(id, command.to_s, reply: reply_id)
+  def expect_response(id, reply_id, command, payload = nil, raw = false, user_id = nil) : Channel(Request)
+    req = Request.new(id, command.to_s, reply: reply_id, user_id: user_id)
     if payload
       req.payload = raw ? payload.to_s : payload.to_json
     end

--- a/src/placeos-driver/protocol/management.cr
+++ b/src/placeos-driver/protocol/management.cr
@@ -115,7 +115,7 @@ class PlaceOS::Driver::Protocol::Management
     Array(String).from_json promise.get
   end
 
-  def execute(module_id : String, payload : String?) : String
+  def execute(module_id : String, payload : String?, user_id : String? = nil) : String
     raise "module #{module_id} not running, terminated" if terminated?
     promise = Promise.new(String)
 
@@ -126,7 +126,7 @@ class PlaceOS::Driver::Protocol::Management
       seq
     end
 
-    @events.send(Request.new(module_id, "exec", payload, seq: sequence))
+    @events.send(Request.new(module_id, "exec", payload, seq: sequence, user_id: user_id))
     promise.get
   end
 

--- a/src/placeos-driver/protocol/request.cr
+++ b/src/placeos-driver/protocol/request.cr
@@ -9,11 +9,17 @@ require "../driver_model"
 class PlaceOS::Driver::Protocol::Request
   include JSON::Serializable
 
-  def initialize(@id, @cmd, @payload = nil, @error = nil, @backtrace = nil, @seq = nil, @reply = nil)
+  def initialize(
+    @id, @cmd, @payload = nil, @error = nil, @backtrace = nil,
+    @seq = nil, @reply = nil, @user_id = nil
+  )
   end
 
   property id : String
   property cmd : String
+
+  # Security context
+  property user_id : String?
 
   # Used to track request and responses
   property seq : UInt64?

--- a/src/placeos-driver/proxy/driver.cr
+++ b/src/placeos-driver/proxy/driver.cr
@@ -94,10 +94,11 @@ class PlaceOS::Driver::Proxy::Driver
       # Generate request body
       request = PlaceOS::Driver::Proxy::Driver.__build_request__(function_name, function, arguments, named_args, {name: @module_name, index: @index, id: @module_id})
 
-      @system.logger.debug { "executing request on #{@module_name}_#{@index}: #{request}" }
+      user_id = Fiber.current.name
+      @system.logger.debug { "executing request on #{@module_name}_#{@index}: #{request} as #{user_id || "internal"}" }
 
       # Parse the execute response
-      channel = PlaceOS::Driver::Protocol.instance.expect_response(@module_id, @reply_id, "exec", request, raw: true)
+      channel = PlaceOS::Driver::Protocol.instance.expect_response(@module_id, @reply_id, "exec", request, raw: true, user_id: user_id)
 
       # Grab the result if required
       lazy do

--- a/src/placeos-driver/proxy/remote_driver.cr
+++ b/src/placeos-driver/proxy/remote_driver.cr
@@ -69,7 +69,8 @@ module PlaceOS::Driver::Proxy
       @sys_id : String,
       @module_name : String,
       @index : Int32,
-      @discovery : HoundDog::Discovery = HoundDog::Discovery.new(CORE_NAMESPACE)
+      @discovery : HoundDog::Discovery = HoundDog::Discovery.new(CORE_NAMESPACE),
+      @user_id : String? = nil
     )
       @error_details = {@sys_id, @module_name, @index}
     end
@@ -79,7 +80,8 @@ module PlaceOS::Driver::Proxy
       @sys_id : String,
       @module_name : String,
       @index : Int32 = 1,
-      @discovery : HoundDog::Discovery = HoundDog::Discovery.new(CORE_NAMESPACE)
+      @discovery : HoundDog::Discovery = HoundDog::Discovery.new(CORE_NAMESPACE),
+      @user_id : String? = nil
     )
       @error_details = {@sys_id, @module_name, 1}
     end
@@ -169,7 +171,8 @@ module PlaceOS::Driver::Proxy
       function : String,
       args = nil,
       named_args = nil,
-      request_id : String? = nil
+      request_id : String? = nil,
+      user_id : String? = @user_id
     ) : String
       metadata = metadata?
       raise Error.new(ErrorCode::ModuleNotFound, "could not find module", *@error_details) unless metadata
@@ -181,6 +184,7 @@ module PlaceOS::Driver::Proxy
 
       exec_args = args || named_args
 
+      # TODO:: this needs to support being provided an optional user_id
       Core::Client.client(which_core, request_id) do |client|
         client.execute(module_id, function, exec_args)
       end

--- a/src/placeos-driver/proxy/remote_driver.cr
+++ b/src/placeos-driver/proxy/remote_driver.cr
@@ -183,10 +183,8 @@ module PlaceOS::Driver::Proxy
       raise Error.new(ErrorCode::ModuleNotFound, "could not find module id", *@error_details) unless module_id
 
       exec_args = args || named_args
-
-      # TODO:: this needs to support being provided an optional user_id
       Core::Client.client(which_core, request_id) do |client|
-        client.execute(module_id, function, exec_args)
+        client.execute(module_id, function, exec_args, user_id: user_id)
       end
     end
 


### PR DESCRIPTION
using Fiber names we can associate users with code execution at the driver level.
This is good for logging and useful in Logic modules where user identity might be important.