### PR TITLE
fix(driver specs runner): ensure transmission processing is synced

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 5.5.0
+version: 5.5.1
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -178,7 +178,7 @@ abstract class PlaceOS::Driver
   end
 
   def define_setting(name, value)
-    PlaceOS::Driver::Protocol.instance.request(@__module_id__, "setting", {name, value})
+    PlaceOS::Driver::Protocol.instance.request(@__module_id__, :setting, {name, value})
   end
 
   # Queuing
@@ -209,7 +209,7 @@ abstract class PlaceOS::Driver
 
   def publish(channel, message)
     if @__edge_driver__
-      PlaceOS::Driver::Protocol.instance.request(channel, "publish", message, raw: true)
+      PlaceOS::Driver::Protocol.instance.request(channel, :publish, message, raw: true)
     else
       RedisStorage.with_redis &.publish("placeos/#{channel}", message.to_s)
     end

--- a/src/placeos-driver/driver-specs/runner.cr
+++ b/src/placeos-driver/driver-specs/runner.cr
@@ -448,7 +448,7 @@ class DriverSpecs
     @event_mutex.synchronize do
       if @transmissions.empty?
         channel = Channel(Bytes).new(1)
-        @expected_transmissions << channel
+        @expected_transmissions << channel.not_nil!
       end
     end
 
@@ -458,13 +458,13 @@ class DriverSpecs
       spawn(same_thread: true) do
         sleep timeout
         if sent.empty?
-          channel.close
+          channel.not_nil!.close
           puts "level=ERROR : timeout waiting for expected data\n-> expecting: #{tdata.inspect}".colorize(:red)
         end
       end
 
       begin
-        sent = channel.receive
+        sent = channel.not_nil!.receive
       ensure
         @event_mutex.synchronize { @expected_transmissions.delete(channel) }
       end


### PR DESCRIPTION
prevents false negatives due to race conditions in device driver specs