### PR TITLE
fix(protocol): add missing redis PUBLISH proxy handler

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 5.6.0
+version: 5.7.0
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/spec/protocol_management_spec.cr
+++ b/spec/protocol_management_spec.cr
@@ -82,13 +82,15 @@ describe PlaceOS::Driver::Protocol::Management do
     redis_set = 0
     redis_hset = 0
     redis_clear = 0
+    redis_publish = 0
     manager.on_redis = ->(action : PlaceOS::Driver::Protocol::Management::RedisAction, hash : String, key : String, value : String?) {
       puts "\n#{hash} -> #{key} -> #{value}\n"
 
       case action
-      in .set?   then redis_set += 1
-      in .hset?  then redis_hset += 1
-      in .clear? then redis_clear += 1
+      in .set?     then redis_set += 1
+      in .hset?    then redis_hset += 1
+      in .clear?   then redis_clear += 1
+      in .publish? then redis_publish += 1
       end
     }
 
@@ -121,6 +123,9 @@ describe PlaceOS::Driver::Protocol::Management do
     redis_set.should eq 1
     # Connected status
     redis_hset.should eq 1
+
+    # Nothing should be published
+    redis_publish.should eq 0
 
     # Named params
     manager.execute("mod-management-test", %({

--- a/src/placeos-driver/protocol/management.cr
+++ b/src/placeos-driver/protocol/management.cr
@@ -26,7 +26,9 @@ class PlaceOS::Driver::Protocol::Management
     HSET
     SET
     CLEAR
+    PUBLISH
   end
+
   property on_redis : Proc(RedisAction, String, String, String?, Nil) = ->(action : RedisAction, hash_id : String, key_name : String, status_value : String?) {}
 
   getter? terminated = false
@@ -486,6 +488,10 @@ class PlaceOS::Driver::Protocol::Management
     when .clear?
       hash_id = request.id
       on_redis.call(RedisAction::CLEAR, hash_id, "clear", nil)
+    when .publish?
+      channel = request.id
+      value = request.payload.not_nil!
+      on_redis.call(RedisAction::PUBLISH, channel, value, nil)
     else
       Log.warn { "unexpected command in process events #{request.cmd}" }
     end


### PR DESCRIPTION
Recent changes added support for a publish command.
This adds the handler for the new event.