### PR TITLE
fix: use Promise's catch

### DIFF
--- a/src/placeos-driver/driver_manager.cr
+++ b/src/placeos-driver/driver_manager.cr
@@ -85,15 +85,12 @@ class PlaceOS::Driver::DriverManager
     # a driver might be making a HTTP request in on_load for exampe which
     # could block for a long time, resulting in poor feedback
     if driver.responds_to?(:on_load)
-      begin
-        loaded = Promise.defer(same_thread: true, timeout: 6.second) do
-          driver.on_load
-          nil
-        end
-        loaded.get
-      rescue error
+      Promise.defer(same_thread: true, timeout: 6.second) do
+        driver.on_load
+        nil
+      end.catch do |error|
         logger.error(exception: error) { "in the on_load function of #{driver.class} (#{@module_id})" }
-      end
+      end.get
     end
 
     begin
@@ -116,17 +113,15 @@ class PlaceOS::Driver::DriverManager
     @transport.terminate
     driver = @driver
     if driver.responds_to?(:on_unload)
-      begin
-        # we don't want a driver blocking here and hence never shutting down
-        unloaded = Promise.defer(same_thread: true, timeout: 6.second) do
-          driver.on_unload
-          nil
-        end
-        unloaded.get
-      rescue error
+      # Ensure driver does not block here, otherwise it will never terminate
+      Promise.defer(same_thread: true, timeout: 6.second) do
+        driver.on_unload
+        nil
+      end.catch do |error|
         logger.error(exception: error) { "in the on_unload function of #{driver.class} (#{@module_id})" }
-      end
+      end.get
     end
+
     @requests.close
     @queue.terminate
     @schedule.terminate


### PR DESCRIPTION
Errors can be swallowed by the fiber encasing the deferred promise.