### PR TITLE
fix(protocol manager): ensure IO closed on driver exit

### DIFF
--- a/src/placeos-driver/protocol/management.cr
+++ b/src/placeos-driver/protocol/management.cr
@@ -363,7 +363,13 @@ class PlaceOS::Driver::Protocol::Management
     status = $?
     last_exit_code = status.exit_code.to_s
     Log.warn { {message: "driver process exited with #{last_exit_code}", driver_path: @driver_path} } unless status.success?
-    @events.send(Request.new(last_exit_code, :exited))
+
+    begin
+      @io.try &.close
+    rescue
+    ensure
+      @events.send(Request.new(last_exit_code, :exited))
+    end
   end
 
   private def relaunch(last_exit_code : String) : Nil

--- a/src/placeos-driver/protocol/management.cr
+++ b/src/placeos-driver/protocol/management.cr
@@ -368,6 +368,7 @@ class PlaceOS::Driver::Protocol::Management
       @io.try &.close
     rescue
     ensure
+      @io = nil
       @events.send(Request.new(last_exit_code, :exited))
     end
   end


### PR DESCRIPTION
When testing the hypothesis that driver's blocked on IO do not successfully restart, we noticed that an IO could remain open to the driver, potentially blocking the `relaunch` event from triggering a reload of the driver.