### PR TITLE
refactor: directly serialise `Request` structs

### DIFF
--- a/src/placeos-driver/protocol/management.cr
+++ b/src/placeos-driver/protocol/management.cr
@@ -267,14 +267,12 @@ class PlaceOS::Driver::Protocol::Management
     io.flush
   end
 
-  private def exec(module_id : String, payload : String, seq : UInt64) : Nil
-    if (io = @io) && modules[module_id]?
-      json = %({"id":"#{module_id}","cmd":"exec","seq":#{seq},"payload":#{payload.to_json}})
-      io.write_bytes json.bytesize
-      io.write json.to_slice
+  private def exec(request : Request) : Nil
+    if (io = @io) && modules[request.id]?
+      request.to_json(io)
       io.flush
-    elsif promise = request_lock.synchronize { @requests.delete(seq) }
-      promise.reject Exception.new("module #{module_id} not running on this host")
+    elsif promise = request_lock.synchronize { @requests.delete(request.seq) }
+      promise.reject Exception.new("module #{request.id} not running on this host")
     end
   end
 

--- a/src/placeos-driver/protocol/request.cr
+++ b/src/placeos-driver/protocol/request.cr
@@ -57,10 +57,16 @@ module PlaceOS
     property seq : UInt64?
 
     # For driver to driver comms to route the request back to the originating module
+    @[JSON::Field(emit_null: false)]
     property reply : String?
 
+    @[JSON::Field(converter: String::RawConverter)]
     property payload : String?
+
+    @[JSON::Field(emit_null: false)]
     property error : String?
+
+    @[JSON::Field(emit_null: false)]
     property backtrace : Array(String)?
 
     def set_error(error)


### PR DESCRIPTION
This refactor ensures that additions of fields to the `Request` object are simply propagated and prevents the construction of an intermediary object when serialising.