### PR TITLE
fix(protocol): pass `user_id` in the hand-constructed exec request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - 1.0.0
           - 1.1.1
           - 1.2.2
+          - 1.3.0
         include:
           - stable: false
             crystal: nightly

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 5.9.9
+version: 5.9.10
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/src/placeos-driver/protocol/management.cr
+++ b/src/placeos-driver/protocol/management.cr
@@ -182,7 +182,7 @@ class PlaceOS::Driver::Protocol::Management
         case (request = @events.receive).cmd
         when .start?     then start(request)
         when .stop?      then stop(request)
-        when .exec?      then exec(request.id, request.payload.not_nil!, request.seq.not_nil!)
+        when .exec?      then exec(request.id, request.payload.not_nil!, request.seq.not_nil!, request.user_id)
         when .update?    then update(request)
         when .debug?     then debug(request.id)
         when .exited?    then relaunch(request.id)
@@ -267,9 +267,10 @@ class PlaceOS::Driver::Protocol::Management
     io.flush
   end
 
-  private def exec(module_id : String, payload : String, seq : UInt64) : Nil
+  private def exec(module_id : String, payload : String, seq : UInt64, user_id : String?) : Nil
     if (io = @io) && modules[module_id]?
-      json = %({"id":"#{module_id}","cmd":"exec","seq":#{seq},"payload":#{payload.to_json}})
+      user_id = user_id ? %("#{user_id}") : "null"
+      json = %({"id":"#{module_id}","user_id":#{user_id},"cmd":"exec","seq":#{seq},"payload":#{payload.to_json}})
       io.write_bytes json.bytesize
       io.write json.to_slice
       io.flush


### PR DESCRIPTION
This PR adds the `user_id` in `exec` requests.

Ideally, we would serialize the `Request` object directly to simplify changes to the data model.