### PR TITLE
feat: add success and failure codes to request processing

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 5.9.10
+version: 6.0.0
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/spec/protocol_management_spec.cr
+++ b/spec/protocol_management_spec.cr
@@ -44,13 +44,13 @@ describe PlaceOS::Driver::Protocol::Management do
         "a": 1,
         "b": 2
       }
-    })).should eq("3")
+    })).should eq({"3", 200})
 
     # Regular arguments
     manager.execute("mod-management-test", %({
       "__exec__": "add",
       "add": [1, 2]
-    })).should eq("3")
+    })).should eq({"3", 200})
 
     logged = nil
     manager.debug("mod-management-test") do |debug_json|
@@ -134,7 +134,7 @@ describe PlaceOS::Driver::Protocol::Management do
         "a": 1,
         "b": 2
       }
-    })).should eq("3")
+    })).should eq({"3", 200})
 
     redis_hset.should eq 2
 
@@ -142,7 +142,7 @@ describe PlaceOS::Driver::Protocol::Management do
     manager.execute("mod-management-test", %({
       "__exec__": "add",
       "add": [1, 2]
-    })).should eq("3")
+    })).should eq({"3", 200})
 
     # Status shouldn't have changed, so we only expect this to be 1
     redis_hset.should eq 2

--- a/src/placeos-driver/exception.cr
+++ b/src/placeos-driver/exception.cr
@@ -1,10 +1,11 @@
 class PlaceOS::Driver::RemoteException < Exception
   getter? backtrace
+  getter code : Int32
 
-  def initialize(message : String?, class_name : String?, @backtrace = [] of String)
+  def initialize(message : String?, class_name : String?, @backtrace = [] of String, @code : Int32 = 500)
     @message = "#{message} (#{class_name})"
   end
 
-  def initialize(@message : String, @cause : Exception, @backtrace : Array(String))
+  def initialize(@message : String, @cause : Exception, @backtrace : Array(String), @code : Int32 = 500)
   end
 end

--- a/src/placeos-driver/protocol/request.cr
+++ b/src/placeos-driver/protocol/request.cr
@@ -59,11 +59,13 @@ module PlaceOS
     # For driver to driver comms to route the request back to the originating module
     property reply : String?
 
+    property code : Int32? = nil
     property payload : String?
     property error : String?
     property backtrace : Array(String)?
 
     def set_error(error)
+      self.code ||= 500
       self.payload = error.message
       self.error = error.class.to_s
       self.backtrace = error.backtrace?
@@ -71,7 +73,7 @@ module PlaceOS
     end
 
     def build_error
-      Driver::RemoteException.new(self.payload, self.error, self.backtrace || [] of String)
+      Driver::RemoteException.new(self.payload, self.error, self.backtrace || [] of String, self.code || 500)
     end
 
     # Not part of the JSON payload, so we don't need to re-parse a request

--- a/src/placeos-driver/proxy/remote_driver.cr
+++ b/src/placeos-driver/proxy/remote_driver.cr
@@ -185,6 +185,8 @@ module PlaceOS::Driver::Proxy
       exec_args = args || named_args
       Core::Client.client(which_core, request_id) do |client|
         client.execute(module_id, function, exec_args, user_id: user_id)
+        # TODO:: return the code, requires core to return the module code
+        # this simplest way to do this is probably via a header
       end
     end
 

--- a/src/placeos-driver/task.cr
+++ b/src/placeos-driver/task.cr
@@ -31,6 +31,7 @@ class PlaceOS::Driver::Task
   @timer : Tasker::Task?
   @processing : Proc(Bytes, Task, Nil)?
   @error_class : String?
+  property code : Int32? = nil
 
   enum State
     Success
@@ -108,7 +109,7 @@ class PlaceOS::Driver::Task
   end
 
   # result should support conversion to JSON
-  def success(result = nil)
+  def success(result = nil, @code = 200)
     @state = :success
     @wait = false
 
@@ -154,7 +155,7 @@ class PlaceOS::Driver::Task
   end
 
   # Failed except we don't want to retry
-  def abort(reason = nil)
+  def abort(reason = nil, @code = 500)
     stop_timers
     @wait = false
     @state = :abort


### PR DESCRIPTION
I think it's worth having a discussion if this is actually worth implementing.
Like what are the advantages etc.

The driver level protocol is backwards compatible and we would have to:
* update the core API to return the code (in a header which would maintain backwards compatibility)
* update the core API Client to return the code
* update rest-api to return the code

in the scheme of things, not the biggest change