### PR TITLE
feat: add `rescue_from` helper methods

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 6.0.0
+version: 6.1.0
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/spec/driver_spec.cr
+++ b/spec/driver_spec.cr
@@ -52,6 +52,8 @@ describe PlaceOS::Driver::DriverManager do
       "switch_input":{
         "input":{"type":"string","enum":["hdmi","display_port","hd_base_t"],"title":"Helper::TestDriver::Input"}
       },
+      "divide_by":{"num": {"type": "integer", "title": "Int32"}},
+      "get_index":{"num": {"type": "integer", "title": "Int32"}},
       "add":{
         "a":{"type":"integer","title":"Int32"},
         "b":{"type":"integer","title":"Int32"}
@@ -77,6 +79,8 @@ describe PlaceOS::Driver::DriverManager do
       "switch_input":{
           "input":["Input"]
       },
+      "divide_by":{"num": ["Int32"]},
+      "get_index":{"num": ["Int32"]},
       "add":{
         "a":["Int32"],
         "b":["Int32"]
@@ -97,6 +101,32 @@ describe PlaceOS::Driver::DriverManager do
       "test_exec":{},
       "implemented_in_base_class":{}
     }).gsub(/\s/, "").gsub(/\|/, " | "))
+  end
+
+  it "should execute functions with global error handlers, without issue" do
+    driver = Helper.new_driver({{PlaceOS::Driver::CONCRETE_DRIVERS.keys.first}}, "mod-988", Helper.protocol[0])
+    driver.is_a?(PlaceOS::Driver).should eq(true)
+
+    # Test no error cases
+    executor = {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.new(%(
+        {
+          "__exec__": "divide_by",
+          "divide_by": {
+            "num": 8
+          }
+        }
+    ))
+    executor.execute(driver).should eq("1")
+
+    executor = {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.new(%(
+        {
+          "__exec__": "get_index",
+          "get_index": {
+            "num": 1
+          }
+        }
+    ))
+    executor.execute(driver).should eq("2")
   end
 
   it "should initialize an instance of driver manager" do

--- a/spec/process_manager_spec.cr
+++ b/spec/process_manager_spec.cr
@@ -388,7 +388,7 @@ describe PlaceOS::Driver::ProcessManager do
   end
 
   it "should recover from errors using global error handlers" do
-    process, input, output, logs, driver_id = Helper.process
+    process, input, output, _logs, driver_id = Helper.process
     process.loaded.size.should eq 1
 
     # execute a task response

--- a/spec/process_manager_spec.cr
+++ b/spec/process_manager_spec.cr
@@ -386,4 +386,58 @@ describe PlaceOS::Driver::ProcessManager do
     process.terminated.receive?
     process.loaded.size.should eq 0
   end
+
+  it "should recover from errors using global error handlers" do
+    process, input, output, logs, driver_id = Helper.process
+    process.loaded.size.should eq 1
+
+    # execute a task response
+    json = {
+      id:      driver_id,
+      cmd:     "exec",
+      payload: %({
+        "__exec__": "divide_by",
+        "divide_by": {
+          "num": 0
+        }
+      }),
+    }.to_json
+    input.write_bytes json.bytesize
+    input.write json.to_slice
+
+    process.loaded[driver_id].queue.online = true
+
+    raw_data = Bytes.new(4096)
+    bytes_read = output.read(raw_data)
+
+    # Check response was returned
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
+    req_out.id.should eq(driver_id)
+    req_out.cmd.result?.should be_true
+    req_out.payload.should eq("-1")
+
+    json = {
+      id:      driver_id,
+      cmd:     "exec",
+      payload: %({
+        "__exec__": "get_index",
+        "get_index": {
+          "num": 5
+        }
+      }),
+    }.to_json
+    input.write_bytes json.bytesize
+    input.write json.to_slice
+
+    process.loaded[driver_id].queue.online = true
+
+    raw_data = Bytes.new(4096)
+    bytes_read = output.read(raw_data)
+
+    # Check response was returned
+    req_out = PlaceOS::Driver::Protocol::Request.from_json(String.new(raw_data[2, bytes_read - 4]))
+    req_out.id.should eq(driver_id)
+    req_out.cmd.result?.should be_true
+    req_out.payload.should eq("-2")
+  end
 end

--- a/spec/test_build.cr
+++ b/spec/test_build.cr
@@ -74,6 +74,26 @@ class Helper
       puts io
     end
 
+    # Test error handling
+    rescue_from DivisionByZeroError do |error|
+      -1
+    end
+
+    def divide_by(num : Int32)
+      12 // num
+    end
+
+    # Test alternative error handling
+    rescue_from IndexError, :handle_index
+
+    protected def handle_index(error)
+      -2
+    end
+
+    def get_index(num : Int32)
+      [1, 2, 3][num]
+    end
+
     # Any method that requires a block is not included in the public API
     def add(a)
       a + yield

--- a/spec/test_build.cr
+++ b/spec/test_build.cr
@@ -75,7 +75,7 @@ class Helper
     end
 
     # Test error handling
-    rescue_from DivisionByZeroError do |error|
+    rescue_from DivisionByZeroError do |_error|
       -1
     end
 
@@ -86,7 +86,7 @@ class Helper
     # Test alternative error handling
     rescue_from IndexError, :handle_index
 
-    protected def handle_index(error)
+    protected def handle_index(_error)
       -2
     end
 

--- a/src/placeos-driver/utilities/rescue_from.cr
+++ b/src/placeos-driver/utilities/rescue_from.cr
@@ -1,0 +1,25 @@
+abstract class PlaceOS::Driver
+  RESCUE_FROM = {} of Nil => Nil
+
+  macro rescue_from(error_class, method = nil, &block)
+    {% if method %}
+      {% RESCUE_FROM[error_class] = {method.id, nil} %}
+    {% else %}
+      {% method = "__on_" + error_class.stringify.underscore.gsub(/\:\:/, "_") %}
+      {% RESCUE_FROM[error_class] = {method.id, block} %}
+    {% end %}
+  end
+
+  macro _rescue_from_inject_functions_
+    # Create functions as required for errors
+    # Skip the generating methods for existing handlers
+    {% for klass, details in RESCUE_FROM %}
+      {% block = details[1] %}
+      {% if block != nil %}
+        protected def {{details[0]}}({{*details[1].args}})
+          {{details[1].body}}
+        end
+      {% end %}
+    {% end %}
+  end
+end


### PR DESCRIPTION
There is an inline form

```crystal
    rescue_from DivisionByZeroError do |error|
      -1
    end
```

and an explicit form

```crystal
    rescue_from IndexError, :handle_index

    protected def handle_index(error)
      -2
    end
```

These only handle errors that occur when executing a function
if the error occurs in the `received` function it must be handled there

fixes #140 