### PR TITLE
fix(proxy/remote_driver): propagate error responses properly

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 6.2.1
+version: 6.3.0
 crystal: ">= 1.0.0"
 
 dependencies:
@@ -12,7 +12,7 @@ dependencies:
 
   placeos-core-client:
     github: placeos/core-client
-    version: ~> 0.4
+    version: ~> 0.5
 
   debug:
     github: Sija/debug.cr

--- a/src/placeos-driver/proxy/driver.cr
+++ b/src/placeos-driver/proxy/driver.cr
@@ -117,7 +117,7 @@ class PlaceOS::Driver::Proxy::Driver
 
         if error = result.error
           backtrace = result.backtrace || [] of String
-          remote_error = PlaceOS::Driver::RemoteException.new "remote exception: #{result.payload}", error, backtrace
+          remote_error = PlaceOS::Driver::RemoteException.new("remote exception: #{result.payload}", error, backtrace, result.code || 500)
           @system.logger.warn(exception: remote_error) { remote_error.message }
           raise remote_error
         else


### PR DESCRIPTION
including providing access to the new response code internally in drivers
