### PR TITLE
fix(`-d`): prevent log leaking into defaults output

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 6.3.5
+version: 6.3.6
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -533,6 +533,7 @@ macro finished
     puts PlaceOS::Startup.print_meta ? %(#{defaults.rchop},#{ {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.metadata.lchop }) : defaults
   elsif PlaceOS::Startup.print_meta
     puts {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.metadata_with_schema
+    exit 0
   end
 
   # inject the rescue_from handlers

--- a/src/placeos-driver.cr
+++ b/src/placeos-driver.cr
@@ -531,6 +531,7 @@ macro finished
   if PlaceOS::Startup.print_defaults
     defaults = PlaceOS::Driver::Utilities::Discovery.defaults
     puts PlaceOS::Startup.print_meta ? %(#{defaults.rchop},#{ {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.metadata.lchop }) : defaults
+    exit 0
   elsif PlaceOS::Startup.print_meta
     puts {{PlaceOS::Driver::CONCRETE_DRIVERS.values.first[1]}}.metadata_with_schema
     exit 0


### PR DESCRIPTION
**Description of the change**

Fixes a bug where log output would break deserialisation of the output of the defaults emitted by a driver