### PR TITLE
feat(driver-specs/runner): add support for testing define_setting

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 6.4.14
+version: 6.4.15
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/src/placeos-driver/driver-specs/runner.cr
+++ b/src/placeos-driver/driver-specs/runner.cr
@@ -332,8 +332,9 @@ class DriverSpecs
               end
             when .setting?
               setting_name, setting_value = Tuple(String, YAML::Any).from_yaml(request.payload.not_nil!)
-              @current_settings[setting_name] = JSON.parse(setting_value.to_json)
-              settings(@current_settings)
+              curr_settings = @current_settings.as_h
+              curr_settings[setting_name] = JSON.parse(setting_value.to_json)
+              settings(curr_settings)
             else
               puts "ignoring command #{request.cmd} in driver-runner server #{request.error}"
             end

--- a/src/placeos-driver/driver-specs/runner.cr
+++ b/src/placeos-driver/driver-specs/runner.cr
@@ -330,6 +330,10 @@ class DriverSpecs
                 @io.write json.to_slice
                 @io.flush
               end
+            when .setting?
+              setting_name, setting_value = Tuple(String, YAML::Any).from_yaml(request.payload.not_nil!)
+              @current_settings[setting_name] = JSON.parse(setting_value.to_json)
+              settings(@current_settings)
             else
               puts "ignoring command #{request.cmd} in driver-runner server #{request.error}"
             end


### PR DESCRIPTION
can spec if the update had the expected in two ways:

```crystal
# directly
define_setting("key", {value: 1234})

# then in the spec:
@current_settings["key"]?.should eq {"value" => 1234}
```

OR

```crystal
# indirectly
define_setting("key", {value: 1234})

# => this triggers a call to `on_update`
def on_update
  self[:key] = setting(Hash(String, Int32), :key)
end

# then in spec
status["key"]?.should eq {"value" => 1234}
```