### PR TITLE
feat(transport): provide a http_uri_override for non-http drivers

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver
-version: 6.5.0
+version: 6.6.0
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/src/placeos-driver/interface/camera.cr
+++ b/src/placeos-driver/interface/camera.cr
@@ -26,6 +26,7 @@ abstract class PlaceOS::Driver
     # Most cameras support presets (either as a feature or via manual positioning)
     abstract def recall(position : String, index : Int32 | String = 0)
     abstract def save_position(name : String, index : Int32 | String = 0)
+    abstract def remove_position(name : String, index : Int32 | String = 0)
 
     enum TiltDirection
       Down


### PR DESCRIPTION
so they can define a custom HTTP endpoint